### PR TITLE
Added LDAP_BASE_GROUPS parameter for groups search base DN.

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -21,6 +21,7 @@ function logger(userName) {
 
 var Users = module.exports = function(){
   this._base = nconf.get("LDAP_BASE");
+  this._baseGroups = nconf.get("LDAP_BASE_GROUPS") || nconf.get("LDAP_BASE");
   this._client = ldap_clients.client;
   this._binder = ldap_clients.binder;
   this._groupsCache = require('./cache').groups;
@@ -294,7 +295,7 @@ Users.prototype._getAllGroupsAD = function (dn, callback) {
               .timeout(nconf.get('GROUPS_TIMEOUT_SECONDS') * 1000)
               .once();
 
-  self._client.search(self._base, opts, function(err, res){
+  self._client.search(self._baseGroups, opts, function(err, res){
     if (err) {
       return callback(err);
     }


### PR DESCRIPTION
This new parameter allows a Base DN different than LDAP_BASE for group search.