### PR TITLE
Bug in CreateConnection on win32 installs

### DIFF
--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -11,7 +11,7 @@ function createConnection () {
   var tlsOptions = null;
 
   if (process.platform === 'win32' &&
-      nconf.get('LDAP_URL').toLowerCase().substr(0, 5) === 'ldaps') {
+      nconf.get('LDAP_URL').toString().toLowerCase().substr(0, 5) === 'ldaps') {
 
     var certs = require('windows-certs');
 


### PR DESCRIPTION
nconf.get() doesn't appear to return a string, so .toLowerCase() isn't available and ends up breaking on win32 installs.
