### PR TITLE
Fix proxy tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('./lib/initConf');
 require('colors');
 require('./eventlog');
 require('./lib/add_certs');
@@ -20,7 +21,6 @@ process.on('uncaughtException', function(err) {
 }).once('SIGTERM', end)
   .once('SIGINT', end);
 
-require('./lib/initConf');
 
 var nconf = require('nconf');
 var ws_client;


### PR DESCRIPTION
When the connector can only use a PROXY, the admin dashboard breaks because one of the tests is not using the PROXY. 