### PR TITLE
Allow users to authenticate even if their password is expired or password change is required

### DIFF
--- a/lib/errors/AccountDisabled.js
+++ b/lib/errors/AccountDisabled.js
@@ -1,0 +1,13 @@
+var util = require('util');
+
+function AccountDisabled(username) {
+  this.message = "Account disabled";
+  this.username = username;
+  this.name = 'AccountDisabled';
+  Error.call(this, this.message);
+  Error.captureStackTrace(this, this.constructor);
+}
+
+util.inherits(AccountDisabled, Error);
+
+module.exports = AccountDisabled;

--- a/lib/errors/AccountDisabled.js
+++ b/lib/errors/AccountDisabled.js
@@ -1,8 +1,8 @@
 var util = require('util');
 
-function AccountDisabled(username) {
+function AccountDisabled(profile) {
   this.message = "Account disabled";
-  this.username = username;
+  this.profile = profile;
   this.name = 'AccountDisabled';
   Error.call(this, this.message);
   Error.captureStackTrace(this, this.constructor);

--- a/lib/errors/AccountExpired.js
+++ b/lib/errors/AccountExpired.js
@@ -1,8 +1,8 @@
 var util = require('util');
 
-function AccountExpired(username) {
+function AccountExpired(profile) {
   this.message = "Account expired";
-  this.username = username;
+  this.profile = profile;
   this.name = 'AccountExpired';
   Error.call(this, this.message);
   Error.captureStackTrace(this, this.constructor);

--- a/lib/errors/AccountLocked.js
+++ b/lib/errors/AccountLocked.js
@@ -1,8 +1,8 @@
 var util = require('util');
 
-function AccountLocked(username) {
+function AccountLocked(profile) {
   this.message = "Account locked";
-  this.username = username;
+  this.profile = profile;
   this.name = 'AccountLocked';
   Error.call(this, this.message);
   Error.captureStackTrace(this, this.constructor);

--- a/lib/errors/PasswordChangeRequired.js
+++ b/lib/errors/PasswordChangeRequired.js
@@ -1,8 +1,8 @@
 var util = require('util');
 
-function PasswordChangeRequired(username) {
+function PasswordChangeRequired(profile) {
   this.message = "Password change required";
-  this.username = username;
+  this.profile = profile;
   this.name = 'PasswordChangeRequired';
   Error.call(this, this.message);
   Error.captureStackTrace(this, this.constructor);

--- a/lib/errors/PasswordExpired.js
+++ b/lib/errors/PasswordExpired.js
@@ -1,8 +1,8 @@
 var util = require('util');
 
-function PasswordExpired(username) {
+function PasswordExpired(profile) {
   this.message = "Password expired";
-  this.username = username;
+  this.profile = profile;
   this.name = 'PasswordExpired';
   Error.call(this, this.message);
   Error.captureStackTrace(this, this.constructor);

--- a/lib/initConf.js
+++ b/lib/initConf.js
@@ -19,18 +19,20 @@ nconf.env('||')
      })
      .env()
      .defaults({
-        PORT:                   4000,
-        SESSION_SECRET:         'a1b2c3d4567',
-        AUTHENTICATION:         'FORM',
-        LDAP_SEARCH_QUERY:      '(&(objectCategory=person)(anr={0}))',
-        LDAP_SEARCH_ALL_QUERY:  '(objectCategory=person)',
-        LDAP_SEARCH_GROUPS:     '(member:1.2.840.113556.1.4.1941:={0})',
-        LDAP_USER_BY_NAME:      '(sAMAccountName={0})',
-        WSFED_ISSUER:           'urn:auth0',
-        AGENT_MODE:             true,
-        GROUPS:                 true,
-        LDAP_HEARTBEAT_SECONDS: 60,
-        GROUPS_TIMEOUT_SECONDS: 20,
-        GROUP_PROPERTY:         'cn',
-        GROUPS_CACHE_SECONDS:   600
+        PORT:                                 4000,
+        SESSION_SECRET:                       'a1b2c3d4567',
+        AUTHENTICATION:                       'FORM',
+        LDAP_SEARCH_QUERY:                    '(&(objectCategory=person)(anr={0}))',
+        LDAP_SEARCH_ALL_QUERY:                '(objectCategory=person)',
+        LDAP_SEARCH_GROUPS:                   '(member:1.2.840.113556.1.4.1941:={0})',
+        LDAP_USER_BY_NAME:                    '(sAMAccountName={0})',
+        WSFED_ISSUER:                         'urn:auth0',
+        AGENT_MODE:                           true,
+        GROUPS:                               true,
+        LDAP_HEARTBEAT_SECONDS:               60,
+        GROUPS_TIMEOUT_SECONDS:               20,
+        GROUP_PROPERTY:                       'cn',
+        GROUPS_CACHE_SECONDS:                 600,
+        AUTH_WHEN_PASSWORD_EXPIRED:           false,
+        AUTH_WHEN_PASSWORD_CHANGE_REQUIRED:   false
      });

--- a/lib/initConf.js
+++ b/lib/initConf.js
@@ -33,6 +33,6 @@ nconf.env('||')
         GROUPS_TIMEOUT_SECONDS:               20,
         GROUP_PROPERTY:                       'cn',
         GROUPS_CACHE_SECONDS:                 600,
-        AUTH_WHEN_PASSWORD_EXPIRED:           false,
-        AUTH_WHEN_PASSWORD_CHANGE_REQUIRED:   false
+        ALLOW_PASSWORD_EXPIRED:               false,
+        ALLOW_PASSWORD_CHANGE_REQUIRED:       false
      });

--- a/lib/users.js
+++ b/lib/users.js
@@ -5,6 +5,7 @@ var ldap_clients = require('./ldap');
 var cb = require('cb');
 var graph = require('./graph');
 
+var AccountDisabled = require('./errors/AccountDisabled');
 var AccountExpired = require('./errors/AccountExpired');
 var AccountLocked = require('./errors/AccountLocked');
 var PasswordChangeRequired = require('./errors/PasswordChangeRequired');
@@ -74,8 +75,10 @@ Users.prototype.validate = function (userName, password, callback) {
     binder.bind(profile.dn, password, function(err) {
       if (err) {
         if (err instanceof ldap.InvalidCredentialsError) {
+          var detailedError = getDetailedError(err);
+          profile.last_ldap_status = detailedError.code;
           return self.enrichProfile(profile, function (e, profile) {
-            callback(getDetailedError(profile, err));
+            callback(new detailedError.err_type(profile));
           });
         } else {
           return callback(UnexpectedError.wrap(err));
@@ -85,6 +88,7 @@ Users.prototype.validate = function (userName, password, callback) {
       log('Bind OK.');
 
       log('Enrich profile.');
+      profile.last_ldap_status = 'active';
       self.enrichProfile(profile, function (err, profile) {
         log('Enrich profile OK.');
         return callback(null, profile);
@@ -93,20 +97,23 @@ Users.prototype.validate = function (userName, password, callback) {
   });
 };
 
-function getDetailedError(profile, invalidCredentialsError) {
+// Get detailed error for AD: http://www-01.ibm.com/support/docview.wss?uid=swg21290631
+function getDetailedError(invalidCredentialsError) {
   if (invalidCredentialsError && invalidCredentialsError.message) {
     if (invalidCredentialsError.message.indexOf('data 532') > -1) {
-      return new PasswordExpired(profile);
+      return { code: 'password_expired', err_type: PasswordExpired };
+    } else if (invalidCredentialsError.message.indexOf('data 533') > -1 || invalidCredentialsError.message.indexOf('data 534') > -1) {
+      return { code: 'account_disabled', err_type: AccountDisabled };
     } else if (invalidCredentialsError.message.indexOf('data 701') > -1) {
-      return new AccountExpired(profile);
+      return { code: 'account_expired', err_type: AccountExpired };
     } else if (invalidCredentialsError.message.indexOf('data 773') > -1) {
-      return new PasswordChangeRequired(profile);
+      return { code: 'password_change_required', err_type: PasswordChangeRequired };
     } else if (invalidCredentialsError.message.indexOf('data 775') > -1) {
-      return new AccountLocked(profile);
+      return { code: 'account_locked', err_type: AccountLocked };
     }
   }
 
-  return new WrongPassword(profile);
+  return { code: 'wrong_password', err_type: WrongPassword };
 }
 
 function getProperObject(entry) {

--- a/lib/users.js
+++ b/lib/users.js
@@ -76,7 +76,7 @@ Users.prototype.validate = function (userName, password, callback) {
       if (err) {
         if (err instanceof ldap.InvalidCredentialsError) {
           var detailedError = getDetailedError(err);
-          profile.last_ldap_status = detailedError.code;
+          profile.ldapStatus = detailedError.code;
           return self.enrichProfile(profile, function (e, profile) {
             callback(new detailedError.err_type(profile));
           });
@@ -88,7 +88,7 @@ Users.prototype.validate = function (userName, password, callback) {
       log('Bind OK.');
 
       log('Enrich profile.');
-      profile.last_ldap_status = 'active';
+      profile.ldapStatus = 'active';
       self.enrichProfile(profile, function (err, profile) {
         log('Enrich profile OK.');
         return callback(null, profile);

--- a/ws_validator.js
+++ b/ws_validator.js
@@ -14,8 +14,8 @@ var cert = {
   cert: fs.readFileSync(__dirname + '/certs/cert.pem')
 };
 
-var authenticate_when_password_expired = nconf.get('AUTH_WHEN_PASSWORD_EXPIRED');
-var authenticate_when_password_change_required = nconf.get('AUTH_WHEN_PASSWORD_CHANGE_REQUIRED');
+var authenticate_when_password_expired = nconf.get('ALLOW_PASSWORD_EXPIRED');
+var authenticate_when_password_change_required = nconf.get('ALLOW_PASSWORD_CHANGE_REQUIRED');
 
 var socket_server_address = nconf.get('AD_HUB').replace(/^http/i, 'ws');
 var ws = module.exports = new WebSocket(socket_server_address);


### PR DESCRIPTION
So currently, when a user's password is expired or needs to be changed the user is blocked. This means that the user is blocked from using Auth0 until the password is changed.

Users that are not in the corporate network might not even have a way to immediately change their password.

This PR gives developers more control. If they want, they can allow the authentication transaction to continue, by changing these settings to true:

```
AUTH_WHEN_PASSWORD_EXPIRED:           true,
AUTH_WHEN_PASSWORD_CHANGE_REQUIRED:   true
```

Now in addition to that, they can use the profile mapper to add some additional information about the user to the profile which is shared with Auth0, as follows:

```
  profile['ldapStatus'] = raw_data['ldapStatus'];
  profile['ldapStatusDate'] = new Date();
```

`ldapStatus` will have a value like `password_expired` or `password_change_required`. By adding this info to the user profile we'll continue the authentication flow and we'll be able to run rules. One rule the customer could write is a redirect rule that is triggered when `user.ldapStatus === password_expired or password_change_required`. In that case they can show a page like in ADFS / Azure AD, where they force the user to change their password just like here: https://github.com/auth0/rules/tree/master/redirect-rules/active-directory-pwd-reset-policy