### PR TITLE
Enable multiple replacements in LDAP_USER_BY_NAME setting

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -150,7 +150,7 @@ Users.prototype.getByUserName = function (userName, callback) {
 
   var opts = {
     scope:  'sub',
-    filter: nconf.get('LDAP_USER_BY_NAME').replace('{0}', userName)
+    filter: nconf.get('LDAP_USER_BY_NAME').replace(/\{0\}/g, userName)
   };
 
   var entries = [];


### PR DESCRIPTION
Currently the `LDAP_USER_BY_NAME` setting in the `config.json` file, when consumed by the Connector, will only allow the first instance of `{0}` to be replaced. This is a limitation when you want the Connector to authenticate a user based on multiple fields (e.g. account name *or* email). 

An example value of `LDAP_USER_BY_NAME` that could in theory make that work is:

```json
{
  "LDAP_USER_BY_NAME": "(|(sAMAccountName={0})(userPrincipalName={0}))"
}
```

This fix makes the above query actually work since before only the first `{0}` value was being replaced by the supplied username value.