### PR TITLE
Adds support for custom CA in linux.Closes #41

### DIFF
--- a/CENTOS.md
+++ b/CENTOS.md
@@ -1,9 +1,10 @@
-+  Install Node 0.8.26 with nave:
++  Install Node 4.4.7 with nave:
 
 ```
 $ curl -o /opt/nave https://raw.github.com/isaacs/nave/master/nave.sh
 $ chmod +x /opt/nave
-$ /opt/nave usemain 0.8.26
+$ /opt/nave install 4.4.7
+$ /opt/nave usemain 4.4.7
 ```
 
 +  Download the repository:
@@ -32,7 +33,9 @@ $ node server.js
 
 +  Add your connector ticket when requested.
 
-+  Add your LDAP settings to `config.json` file and then run the connector again:
++  Add your LDAP URL and LDAP base DN when requested.
+
++  Add your LDAP user settings to `config.json` file and then run the connector again:
 
 ```
 $ vi config.json

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ The first step is creating a new Connection on the dashboard:
 
 __Connections > Enterprise > AD/LDAP__
 
-![](https://puu.sh/7iXKl.png)
+![](https://cdn.auth0.com/docs/media/articles/connections/enterprise/active-directory/ldap-create.png)
 
 Name the connection and check whether you want `Kerberos` enabled for this connection. If you enable this, you need to enter the range of IP addresses from where `Kerberos` authentication will be enabled. These would typically be the intranet where `Kerberos` would work.
 
-![](https://s3.amazonaws.com/blog.auth0.com/adldap_create_01.PNG)
+![](https://cdn.auth0.com/docs/media/articles/connections/enterprise/active-directory/ldap-create-2.png)
 
 __Save__ the configuration. You are done on the Auth0 side! You will then be prompted to download the __AD/LDAP Connector__ on your machine.
 
-![](https://s3.amazonaws.com/blog.auth0.com/adldap_create_02.PNG)
+![](https://cdn.auth0.com/docs/media/articles/connections/enterprise/active-directory/ldap-create-3.png)
 
 > We ship different versions of the Connector to install it on multiple platforms: Windows, Linux and OS X
 
@@ -35,11 +35,11 @@ Keep the __TICKET URL__ at hand as you will need it later.
 #### Auth0 AD LDAP Connector Setup (Windows Agent)
 On Windows, the Connector is packaged as a standard installer file (__MSI__). Run it on the machine you want to install it and follow the installation wizard:
 
-![](https://s3.amazonaws.com/blog.auth0.com/adldap_01.PNG)
+![](https://cdn.auth0.com/docs/media/articles/connector/install/adldap-connector-setup.png)
 
-![](https://s3.amazonaws.com/blog.auth0.com/adldap_02.PNG)
+> The __AD/LDAP Connector__ in Windows is installed as a Service: 
 
-> The __AD/LDAP Connector__ in Windows is installed as a Service: ![](https://s3.amazonaws.com/blog.auth0.com/adldap_06.PNG)
+![](https://cdn.auth0.com/docs/media/articles/connector/install/adldap-connector-services.png)
 
 Once the installation is complete, you will see the following screen on a browser (notice that the browser is opening a page on the local machine).
 
@@ -47,7 +47,7 @@ Enter the __TICKET URL__ that was generated in __Step 1__.
 
 The __Ticket URL__ uniquely identifies this connector in Auth0. Don't share it with anyone. The Connector will use this to communicate with Auth0 Server and automatically complete the configuration.
 
-![](https://s3.amazonaws.com/blog.auth0.com/adldap_03.PNG)
+![]()
 
 If successful, the next screen will allow you to enter your __Active Directory__ connection parameters. Namely:
 
@@ -79,10 +79,10 @@ If you didn't configure `Kerberos` or you are outside your intranet you will be 
 High availability is achieved through multiple instances of the connector running simultaneously.
 
 1.  Install the connector on the first machine and follow all the steps. Once you have the connection running with only one agent move to the next step.
-2.  Install the connector on the second machine, when the browser opens and requests entering the __Ticket URL__, close the window.
-3.  Copy the `certs` folder and `config.json` from `c:\Program Files(x86)\Auth0\ADLDAP Connector` on the first machine to the same location on the second machine.
-4.  Start the Auth0 ADLDAP agent on the second machine.
-5.  Repeat from step 2 to 5 for every node you want to configure.
+2.  In the AD LDAP configuratino page click on __Import / Export__ and then click __Export__. Keep a copy of the zip file.
+3.  Install the connector on the second machine, when the browser opens and requests entering the __Ticket URL__, click on __Import / Export__.
+4.  In the __Import__ section select the file you downloaded from the first machine and click __Upload__.
+5.  Repeat from step 3 to 4 for every node you want to configure.
 
 ## Running behind a proxy
 

--- a/admin/server.js
+++ b/admin/server.js
@@ -1,4 +1,7 @@
-require('../lib/add_certs');
+require('../lib/initConf');
+require('../lib/setupProxy');
+
+var cas = require('../lib/add_certs');
 var os = require('os');
 var fs = require('fs');
 var zip = require('adm-zip');
@@ -18,9 +21,6 @@ var multipart = require('connect-multiparty');
 var test_config = require('./test_config');
 var Users = require('../lib/users');
 
-require('../lib/initConf');
-require('../lib/setupProxy');
-
 app.set('views', __dirname + '/views');
 app.set('view engine', 'ejs');
 app.use(express.static(__dirname + '/public'));
@@ -32,19 +32,21 @@ app.use(session({
 
 var detected_settings = {};
 
-exec('"' + __dirname + '//settings_detector.exe"', function(err, stdout, stderr) {
-  console.log(arguments);
-  try {
-    var parsed = JSON.parse(stdout);
-    console.log(parsed);
-    if (parsed.error) {
-      parsed = {};
-      return;
-    }
-    detected_settings.LDAP_BASE = parsed.baseDN;
-    detected_settings.LDAP_URL = 'ldap://' + parsed.domainController;
-  } catch (er) {}
-});
+if (process.platform === 'win32') {
+  exec('"' + __dirname + '//settings_detector.exe"', function(err, stdout, stderr) {
+    console.log(arguments);
+    try {
+      var parsed = JSON.parse(stdout);
+      console.log(parsed);
+      if (parsed.error) {
+        parsed = {};
+        return;
+      }
+      detected_settings.LDAP_BASE = parsed.baseDN;
+      detected_settings.LDAP_URL = 'ldap://' + parsed.domainController;
+    } catch (er) {}
+  });
+}
 
 function read_current_config() {
   var current_config = {};
@@ -61,15 +63,23 @@ function set_current_config(req, res, next) {
 }
 
 function restart_server(cb) {
-  console.log('Restarting Auth0 ADLDAP Service...');
-  return exec('net stop "Auth0 ADLDAP"', function() {
-    exec('net start "Auth0 ADLDAP"', function() {
-      console.log('Done.');
-      setTimeout(function() {
-        return cb();
-      }, 2000);
+   // required to test immediately after configuration
+  require('../lib/initConf');
+  Users = require('../lib/users');
+
+  if (process.platform === 'win32') {
+    console.log('Restarting Auth0 ADLDAP Service...');
+    return exec('net stop "Auth0 ADLDAP"', function() {
+      exec('net start "Auth0 ADLDAP"', function() {
+        console.log('Done.');
+        setTimeout(function() {
+          return cb();
+        }, 2000);
+      });
     });
-  });
+  }
+
+  cb();
 }
 
 function merge_config(req, res) {
@@ -162,14 +172,28 @@ app.post('/ticket', set_current_config, function(req, res, next) {
     url: info_url,
     json: true
   }, function(err, resp, body) {
-    if (err && err.code === 'ECONNREFUSED') {
-      console.error('Unable to reach auth0 at: ' + info_url);
-      return res.render('index', xtend(req.current_config, {
-        ERROR: 'Unable to connect to Auth0, verify internet connectivity.'
-      }));
-    }
+    if (err){
+      if (err.code === 'ECONNREFUSED') {
+        console.error('Unable to reach auth0 at: ' + info_url);
+        return res.render('index', xtend(req.current_config, {
+          ERROR: 'Unable to connect to Auth0, verify internet connectivity.'
+        }));
+      }
 
-    if (err) {
+      if (err.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' || err.code ==='CERT_UNTRUSTED') {
+        console.error('The Auth0 certificate at ' + info_url + ' could not be validated', err);
+        return res.render('index', xtend(req.current_config, {
+          ERROR: 'The Auth0 server is using a certificate issued by an untrusted Certification Authority. Go to https://auth0.com/docs/connector/ca-certificates for instructions on how to install your certificate Authority. \n ' + err.message
+        }));
+      }
+
+      if (err.code === 'DEPTH_ZERO_SELF_SIGNED_CERT') {
+        console.error('The Auth0 certificate at ' + info_url + ' could not be validated', err);
+        return res.render('index', xtend(req.current_config, {
+          ERROR: 'The Auth0 server is using a selg-signed certificate. Go to https://auth0.com/docs/connector/ca-certificates for instructions on how to install your certificate. \n' + err.message
+        }));
+      }
+
       return res.render('index', xtend(req.current_config, {
         ERROR: 'Network error: ' + err.message
       }));
@@ -183,7 +207,16 @@ app.post('/ticket', set_current_config, function(req, res, next) {
 
     req.body.AD_HUB = body.adHub;
 
-    next();
+    if (!detected_settings.LDAP_URL) {
+      var adLdapSettings = require('../connector-setup/steps/ad-ldap-settings.js');
+      adLdapSettings.discoverSettings(body.connectionDomain, function(config) {
+        console.dir(config);
+        detected_settings = config;
+        next();
+      });
+    } else {
+      next();
+    }
   });
 }, merge_config);
 
@@ -473,6 +506,10 @@ app.get('/users/by-login', function(req, res) {
   });
 });
 
-http.createServer(app).listen(8357, '127.0.0.1', function() {
-  console.log('Listening on http://localhost:8357.');
+cas.inject(function(err) {
+  if (err) console.log('Custom CA certificates were not loaded',err);
+
+  http.createServer(app).listen(8357, '127.0.0.1', function() {
+    console.log('Listening on http://localhost:8357.');
+  });
 });

--- a/connector-setup/index.js
+++ b/connector-setup/index.js
@@ -6,13 +6,14 @@ var program = require('commander');
 var async = require('async');
 var request = require('request');
 var urlJoin = require('url-join');
-
+var cas = require('../lib/add_certs');
 var firewall = require('../lib/firewall');
 var path = require('path');
 
 //steps
 var certificate = require('./steps/certificate');
 var configureConnection = require('./steps/configureConnection');
+var adLdapSettings = require('./steps/ad-ldap-settings');
 
 program
   .version(require('../package.json').version)
@@ -39,6 +40,9 @@ exports.run = function (workingPath, callback) {
         provisioningTicket = pt;
         cb();
       });
+    },
+    function (cb) {
+      cas.inject(cb);
     }, function (cb) {
       var info_url = urlJoin(provisioningTicket, '/info');
       console.log('Loading settings from ticket: ' + info_url);
@@ -48,13 +52,25 @@ exports.run = function (workingPath, callback) {
         json: true
       }, function (err, response, body) {
         if (err) {
-          if (err.code === 'ECONNREFUSED') {
-            console.log('Unable to reach Auth0 at ' + ticket);
-          } else {
-            console.log('Unexpected error while configuring connection: ' + (err.code || err.message));
+          switch(err.code) {
+            case 'ECONNREFUSED':
+              console.log('Unable to reach Auth0 at ' + ticket);
+              break;
+            case 'UNABLE_TO_VERIFY_LEAF_SIGNATURE':
+            case 'CERT_UNTRUSTED':
+              console.error('The Auth0 server is using a certificate issued by an untrusted Certification Authority.', err)
+              console.log('Go to https://auth0.com/docs/connector/ca-certificates for instructions on how to install your CA certificate.');
+              break;
+            case 'DEPTH_ZERO_SELF_SIGNED_CERT':
+              console.error('The Auth0 server is using a self-signed certificate', err)
+              console.log('Go to https://auth0.com/docs/connector/ca-certificates for instructions on how to install your certificate.');
+              break;
+            default:
+              console.error('Unexpected error while configuring connection:', err);
           }
           return cb(err);
         }
+
 
         if (response.statusCode == 404) {
           return cb (new Error('Wrong ticket. Does this connection still exist?'));
@@ -72,7 +88,43 @@ exports.run = function (workingPath, callback) {
 
         info = body;
 
+
         cb();
+      });
+    },
+    function(cb) {
+      var ldap_url = nconf.get('LDAP_URL');
+      var ldap_base = nconf.get('LDAP_BASE');
+
+      if(ldap_url) return cb();
+
+      adLdapSettings.discoverSettings(info.connectionDomain, function(config) {
+        var detectedUrl = '';
+        var detectedDN = ''
+        if (config) {
+          detectedUrl = config.LDAP_URL || '';
+          detectedDN = config.LDAP_BASE || '';
+
+        }
+
+        if (console.restore) console.restore();
+
+        console.log('test');
+        program.prompt('Please enter your LDAP server URL [' + (detectedUrl) + ']: ', function (url) {
+          ldap_url = (url && url.length>0) ? url : detectedUrl;
+
+          program.prompt('Please enter the LDAP server base DN [' + (detectedDN) + ']: ', function (dn) {
+            ldap_base = (dn && dn.length>0) ? dn : detectedDN;
+
+            nconf.set('LDAP_BASE', ldap_base);
+            nconf.set('LDAP_URL', ldap_url);
+            nconf.save();
+
+            if (console.inject) console.inject();
+
+            cb();
+          });
+        });
       });
     },
     function (cb) {

--- a/connector-setup/steps/ad-ldap-settings.js
+++ b/connector-setup/steps/ad-ldap-settings.js
@@ -1,0 +1,82 @@
+var dns = require('dns');
+var ldap = require('ldapjs');
+var net = require('net');
+
+
+function compareSrvRecords(srv1, srv2) {
+  if (srv1.priority < srv2.priority) {
+    return -1;
+  } else if (srv1.priority > srv2.priority) {
+    return 1;
+  } else if (srv1.weight > srv1.weight) {
+    return -1;
+  } else if (srv1.weight < srv1.weight) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+function buildLdapUrl(srv) {
+  return 'ldap://' + srv.name + ':' + srv.port;
+};
+
+function getDomainDN(domain) {
+  var parts = domain.split('.');
+  return 'DC=' + parts.join(',DC=');
+}
+
+function tryLdapServers(domain, urls, cb){
+  if (!urls && urls.length === 0) return cb();
+  var url = urls.shift();
+  var client = ldap.createClient({url: url});
+
+  client.bind('anonymous','', function(err) {
+    if (!err) return cb({
+      LDAP_BASE: getDomainDN(domain),
+      LDAP_URL: url
+    });
+
+    tryLdapServers(domain, urls, cb);
+  });
+}
+
+function tryGetDomainSettings(domains, cb) {
+  if (!domains || domains.length===0) return cb({});
+
+
+  if(!Array.isArray(domains)) {
+    domains = [domains];
+  }
+  var domain = domains.shift();
+
+  dns.resolveSrv('_ldap._tcp.' + domain, function(err, addresses) {
+    if (!addresses || addresses.length === 0) return tryGetDomainSettings(domains, cb);
+    var hostnames = addresses
+      .sort(compareSrvRecords)
+      .map(buildLdapUrl);
+
+    tryLdapServers(domain, hostnames, function(config) {
+      if (!config) return tryGetDomainSettings(domains);
+      cb(config);
+    });
+
+  });
+
+}
+
+function discover(domains, cb){
+  if (!cb) {
+    cb = domains;
+    domains = null;
+  }
+
+  if (!domains) return cb();
+
+  tryGetDomainSettings(domains, cb);
+}
+
+
+module.exports = {
+  discoverSettings : discover
+}

--- a/lib/add_certs.js
+++ b/lib/add_certs.js
@@ -1,15 +1,103 @@
-if (process.platform !== 'win32') return;
-
-var certs = require('windows-certs');
-
 var https = require('https');
+var fs = require('fs');
+var path = require('path');
+var exec = require('child_process').exec;
+var async = require('async');
+var nconf = require('nconf');
 
-var cas = https.globalAgent.options.ca =
-    https.globalAgent.options.ca || [];
+const SSL_OPENSSLDIR_PATTERN = new RegExp(nconf.get('SSL_OPENSSLDIR_PATTERN'));
+const SSL_CA_PATH = nconf.get('SSL_CA_PATH');
+const SSL_CA_FILE = new RegExp(nconf.get('SSL_CA_FILE'), ((process.platform === 'win32') ? 'i': ''));
 
-certs.get({
-  storeLocation: 'LocalMachine',
-  storeName: ['TrustedPeople', 'CertificateAuthority', 'Root']
-}).forEach(function (cert) {
-  cas.push(cert.pem);
-});
+function addCertificates(cb){
+  return function(err, certificates) {
+    if (err) {
+      console.error('Custom/System CAs could not be imported', err);
+      return cb(err);
+    }
+
+    if (certificates) {
+      var cas = https.globalAgent.options.ca =
+        https.globalAgent.options.ca || [];
+
+      if (!cas.__added){
+        console.log('Adding', certificates.length, 'certificates');
+        certificates.forEach(function (cert) {
+          cas.push(cert.pem);
+        });
+        cas.__added = true;
+      }
+    }
+    cb();
+  }
+}
+
+function readPEM(file, cb){
+  //console.log('Reading certificate ' + file);
+  fs.readFile(file, function(err,data) {
+    if (err) return cb(err);
+
+    cb(null, {pem: data});
+  });
+}
+
+function readCertficatesFromPath(certPath, cb){
+  console.log('Reading CA certificates from', certPath);
+  fs.readdir(certPath, function(err, files) {
+    if (err) cb (err);
+
+    files = files
+      .filter(function (file){ return SSL_CA_FILE.test(file);})
+      .map(function(file) {
+        return path.join(certPath, file);
+      });
+    async.map(files, readPEM, cb);
+  });
+}
+
+function readSystemCAs(cb) {
+  switch(process.platform) {
+    case 'win32':
+      console.log('Reading CA certificates from Windows Store');
+      require('windows-certs')
+        .get({
+          storeLocation: 'LocalMachine',
+          storeName: ['TrustedPeople', 'CertificateAuthority', 'Root']
+        },cb);
+      break;
+    case 'freebsd':
+    case 'linux':
+      console.log('Reading CA certificates from OPENSSLDIR');
+      exec('openssl version -d', function(err, stdout, stderr){
+        if (err) return cb(err);
+
+        var match = SSL_OPENSSLDIR_PATTERN.exec(stdout);
+        if (match && match.length > 1) {
+          return readCertficatesFromPath(path.join(match[1], 'certs'), cb);
+        }
+
+        cb();
+      });
+      break;
+    default:
+      console.warn('CA import is not implemented for platform', process.platform);
+      cb();
+  }
+}
+
+function getCAs(cb) {
+  if (SSL_CA_PATH) {
+    readCertficatesFromPath(SSL_CA_PATH, cb);
+  } else {
+    readSystemCAs(cb);
+  }
+}
+
+function injectHttpsCAs(cb) {
+  getCAs(addCertificates(cb));
+}
+
+module.exports = {
+  inject: injectHttpsCAs,
+  getSystemCAs : getCAs
+};

--- a/lib/initConf.js
+++ b/lib/initConf.js
@@ -17,7 +17,10 @@ var defaults = {
   ALLOW_PASSWORD_EXPIRED:               false,
   ALLOW_PASSWORD_CHANGE_REQUIRED:       false,
   OVERRIDE_CONFIG:                      true,
-  CACHE_FILE:                           __dirname + '/../cache.db'
+  CACHE_FILE:                           __dirname + '/../cache.db',
+  SSL_CA_FILE:                          '.+.(pem|crt|cer)$',
+  SSL_CA_PATH:                          false,
+  SSL_OPENSSLDIR_PATTERN:               'OPENSSLDIR\\s*\\:\\s*\\"([^\\"]*)\\"'
 };
 
 if (process.env.OVERRIDE_CONFIG === 'false') {

--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -4,25 +4,14 @@ var exit  = require('./exit');
 var client, binder;
 var crypto = require('./crypto');
 var cb = require('cb');
+var https = require('https');
 
 ldap.Attribute.settings.guid_format = ldap.GUID_FORMAT_D;
 
 function createConnection () {
   var tlsOptions = null;
-
-  if (process.platform === 'win32' &&
-      nconf.get('LDAP_URL').toLowerCase().substr(0, 5) === 'ldaps') {
-
-    var certs = require('windows-certs');
-
-    var cas = certs.get({
-      storeLocation: 'LocalMachine',
-      storeName: ['TrustedPeople', 'CertificateAuthority', 'Root']
-    }).map(function (cert) {
-      return cert.pem;
-    });
-
-    tlsOptions = { ca: cas };
+  if (nconf.get('LDAP_URL').toLowerCase().substr(0, 5) === 'ldaps') {
+    tlsOptions = { ca: https.globalAgent.options.ca };
   }
 
   var connection = ldap.createClient({

--- a/server.js
+++ b/server.js
@@ -33,14 +33,13 @@ connectorSetup.run(__dirname, function(err) {
     return exit(2);
   }
 
-  if(!nconf.get('LDAP_URL')) {
+  if(!nconf.get('LDAP_URL') || !nconf.get('LDAP_BIND_USER') || !nconf.get('LDAP_BIND_CREDENTIALS')) {
     console.error('edit config.json and add your LDAP settings');
     return exit(1);
   }
 
   require('./lib/clock_skew_detector');
   ws_client = require('./ws_validator');
-
   var latency_test = require('./latency_test');
   latency_test.run_many(10);
 

--- a/troubleshoot.js
+++ b/troubleshoot.js
@@ -14,6 +14,7 @@ var winston = require('winston');
 var thumbprint = require('thumbprint');
 var WebSocket = require('ws');
 var isWindows = (process.platform == 'win32');
+var cas = require('./lib/add_certs');
 
 var logger = new winston.Logger({
 	transports: [
@@ -57,6 +58,9 @@ console.log('\n Troubleshooting AD LDAP connector\n');
 
 async.series([
 	function(callback){
+    cas.inject(callback);
+  },
+  function(callback){
 		var HTTP_PROXY = process.env.HTTP_PROXY || process.env.http_proxy;
 		if (HTTP_PROXY) {
 			logger.info('Proxy configured: %s', HTTP_PROXY);

--- a/ws_validator.js
+++ b/ws_validator.js
@@ -49,7 +49,7 @@ function ping (client, count, callback) {
     if (err instanceof cb.TimeoutError) {
       client.removeListener('pong', pong);
       if (count === 4) {
-        return callback(new Error('server did\'t respond to 4 ping commands'));
+        return callback(new Error('server didn\'t respond to 4 ping commands'));
       }
       return ping(client, ++count, callback);
     }


### PR DESCRIPTION
Implements search of custom CA certificates in linux. The approach is based on OpenSSL directories and the fact that most Linux distros use the `OPENSSLDIR` as the repo for certificates.
The documented process for installing certificates ([Ubuntu /etc/ssl/](https://help.ubuntu.com/lts/serverguide/certificates-and-security.html#installing-the-certificate), [Ubuntu, Debian update-ca-certificates](http://askubuntu.com/a/649463), [RedHat, CentOS, Fedora update-ca-trust](https://www.happyassassin.net/2015/01/14/trusting-additional-cas-in-fedora-rhel-centos-dont-append-to-etcpkitlscertsca-bundle-crt-or-etcpkitlscert-pem/)) will make custom CA authorities available for the connector.
Creates new configuration variables `SSL_CA_PATH` and `SSL_CA_FILE` that can be used to specify a non-standard directory for custom CA certificates. This allows to run the connector in other platforms with either self-signed or custom CA certificates
