### PR TITLE
Added error message log

### DIFF
--- a/troubleshoot.js
+++ b/troubleshoot.js
@@ -298,6 +298,8 @@ async.series([
 			});
 		} catch (e) {
 			logger.failed('Connection to LDAP %s.', 'failed'.red);
+			if (e && e.message)
+				logger.error('  > Error: %s', e.message.replace(/\r\n|\r|\n/, '').red);
 			return callback();
 		}
 	}


### PR DESCRIPTION
A customer is having an `error: × Connection to LDAP failed.` message without further explanation. He might be hitting this code path, so I'm logging the message.
