### PR TITLE
Improves connector certificate creation

### DIFF
--- a/connector-setup/steps/certificate.js
+++ b/connector-setup/steps/certificate.js
@@ -21,8 +21,15 @@ module.exports = function (workingPath, info, cb) {
   }
 
   console.log('Generating a self-signed certificate.'.yellow);
-
-  var pems = selfsigned.generate({ subj: '/CN=' + info.connectionDomain , days: 365 });
+  var pems = selfsigned.generate([
+        { shortName: 'CN', value: info.connectionName},
+        { shortName: 'OU', value: info.connectionDomain},
+        { shortName: 'O', value: 'auth0/ad-ldap-connector'}
+      ], {
+        days: 365, 
+        algorithm: 'sha256', 
+        keySize:2048 
+      });
 
   fs.writeFileSync(fileNames.pem, pems.cert);
   fs.writeFileSync(fileNames.key, pems.private);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "randomstring": "~1.0.3",
     "request": "^2.68.0",
     "rimraf": "~2.5.2",
-    "selfsigned": "~1.2.0",
+    "selfsigned": "^1.5.0",
     "stream-rotate": "crigot/stream-rotate#31fe967e6b1d5fdbaf641091877e39e54ae0dd8c",
     "thumbprint": "0.0.1",
     "tunnel": "~0.0.3",


### PR DESCRIPTION
Upgrades `selfsigned` to version 1.5 to apply the following changes:
- Changes the default signing algorithm to _SHA-256_ (Closes #48)
- Increases the key size to _2048_
- Ensures that the certificate includes the Auth0 connection name and domain as attributes
