### PR TITLE
Remove duplicate section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ The __AD/LDAP Connector (1)__, is a bridge between your __Active Directory (2)__
 
 You can install multiple instances of the connector for high availability and load balancing. Also, all connections are out-bound: from the connector to the Auth0 Server, so in general no changes to the firewall need to be applied.
 
-You can install multiple instances of the connector for high availability and load balancing. Also, all connections are out-bound: from the connector to the Auth0 Server, so in general no changes to the firewall need to be applied.
-
 Configuring an AD/LDAP connection in Auth0 requires two simple steps:
 
 ###1. Creating an AD/LDAP Connection in Auth0


### PR DESCRIPTION
The string `You can install multiple instances of the connector for high availability and load balancing. Also, all connections are out-bound: from the connector to the Auth0 Server, so in general no changes to the firewall need to be applied.` was displayed twice in these docs and this change is to remove one of those duplicate sections.