### PR TITLE
Use newer ldapjs and passport-windowsauth (fixes #90, allows to connect to ldaps)

### DIFF
--- a/admin/test_config.js
+++ b/admin/test_config.js
@@ -3,8 +3,6 @@ var url = require('url');
 var net = require('net');
 var WebSocket = require('ws');
 
-ldap.Attribute.settings.guid_format = ldap.GUID_FORMAT_D;
-
 function try_tcp (options, callback) {
   var parsed = url.parse(options.LDAP_URL);
   var port = parsed.port || (parsed.protocol === 'ldap:' ? 389 : 636);

--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -6,8 +6,6 @@ var crypto = require('./crypto');
 var cb = require('cb');
 var https = require('https');
 
-ldap.Attribute.settings.guid_format = ldap.GUID_FORMAT_D;
-
 function createConnection () {
   var tlsOptions = null;
   if (nconf.get('LDAP_URL').toLowerCase().substr(0, 5) === 'ldaps') {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -858,9 +858,9 @@
       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
     },
     "ldapjs": {
-      "version": "0.7.1",
-      "from": "ldapjs@>=0.7.1 <0.8.0",
-      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-0.7.1.tgz"
+      "version": "1.0.1",
+      "from": "ldapjs@>=0.8.0 <1.0.1",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-1.0.1.tgz"
     },
     "level-codec": {
       "version": "6.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1201,9 +1201,9 @@
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
     },
     "passport-windowsauth": {
-      "version": "0.4.1",
-      "from": "passport-windowsauth@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/passport-windowsauth/-/passport-windowsauth-0.4.1.tgz"
+      "version": "1.0.1",
+      "from": "passport-windowsauth@>=1.0.1 <1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-windowsauth/-/passport-windowsauth-1.0.1.tgz"
     },
     "path-array": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "passport": "~0.1.16",
     "passport-local": "~0.1.6",
     "passport-ssl-certificate": "git://github.com/jaredhanson/passport-ssl-certificate.git#826c16d040841ec4b20db1a4cfe8bac81c931462",
-    "passport-windowsauth": "~0.4.1",
+    "passport-windowsauth": "~1.0.1",
     "randomstring": "~1.0.3",
     "request": "^2.68.0",
     "rimraf": "~2.5.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "freeport": "~1.0.2",
     "jsonwebtoken": "5.0.4",
     "kerberos-server": "^1.0.0",
-    "ldapjs": "~0.7.1",
+    "ldapjs": "~1.0.1",
     "level-ttl": "^3.1.0",
     "leveldown": "~1.4.6",
     "levelup": "^1.3.2",


### PR DESCRIPTION
This PR uses ldapjs 1.0.1 and passport-windowsauth 1.0.1 (required by ldapjs 1.0.1) which itself fixes a bug in order to be able to connect to ldaps (as in secure/encrypted LDAP).
This also drops references to guid_format as setting this is no longer supported in this way by ldapjs.