### PR TITLE
added the option to set the ldap alias deref option

### DIFF
--- a/lib/initConf.js
+++ b/lib/initConf.js
@@ -15,6 +15,7 @@ var defaults = {
   GROUP_PROPERTY:                       'cn',
   GROUP_PROPERTIES:                     [],
   GROUPS_CACHE_SECONDS:                 600,
+  GROUPS_DEREF_ALIASES:			0,  
   ALLOW_PASSWORD_EXPIRED:               false,
   ALLOW_PASSWORD_CHANGE_REQUIRED:       false,
   OVERRIDE_CONFIG:                      true,

--- a/lib/users.js
+++ b/lib/users.js
@@ -341,7 +341,8 @@ Users.prototype._getAllGroupsAD = function (dn, callback) {
     scope:      'sub',
     filter:     nconf.get('LDAP_SEARCH_GROUPS').replace(/\{0\}/ig, dn),
     attributes: _.uniq([ 'cn', 'dn', 'memberOf' ].concat(nconf.get('GROUP_PROPERTIES'))),
-    timeLimit:  nconf.get('GROUPS_TIMEOUT_SECONDS')
+    timeLimit:  nconf.get('GROUPS_TIMEOUT_SECONDS'),
+    derefAliases: nconf.get('GROUPS_DEREF_ALIASES')
   };
 
   callback = cb(callback)


### PR DESCRIPTION
See https://github.com/auth0/node-ldapjs/pull/1 for patch in core module (ldapjs)

See https://github.com/auth0/node-ldapjs/blob/master/lib/protocol.js#L16-L19 for possible options for the deref Alias option.