### PR TITLE
fixed anonymous search bug

### DIFF
--- a/connector-setup/index.js
+++ b/connector-setup/index.js
@@ -128,12 +128,23 @@ exports.run = function (workingPath, callback) {
       });
     },
     function (cb) {
+      function anonymousSearchEnabled(enabled) {
+        nconf.set('ANONYMOUS_SEARCH_ENABLED',enabled);
+        connection.destroy();
+        return cb();
+      }
+
       const connection = createConnection();
       connection.search(nconf.get('LDAP_BASE'), '(objectclass=*)', function (err, res) {
-        nconf.set('ANONYMOUS_SEARCH_ENABLED',!err);
+        if (err) {
+          return anonymousSearchEnabled(false);
+        }
+        
         res.once('end', function(){
-          connection.destroy();
-          cb();
+          anonymousSearchEnabled(true);
+        })
+        .once('error',function(err){
+          anonymousSearchEnabled(false);
         });
       });
     },


### PR DESCRIPTION
LDAP `search` returns error asynchronously which wasn't handled properly causing failure when anonymous search was disabled. 