### PR TITLE
During setup, make the certs in the app's workingPath

### DIFF
--- a/connector-setup/steps/certificate.js
+++ b/connector-setup/steps/certificate.js
@@ -3,12 +3,15 @@ var fs          = require('fs');
 var path        = require('path');
 var nconf = require('nconf');
 
-var fileNames = {
-  pem: path.join(process.cwd(), 'certs', 'cert.pem'),
-  key: path.join(process.cwd(), 'certs', 'cert.key')
+function getFileNames(workingPath) {
+  return {
+    pem: path.join(workingPath, 'certs', 'cert.pem'),
+    key: path.join(workingPath, 'certs', 'cert.key')
+  };
 };
 
 module.exports = function (workingPath, info, cb) {
+  let fileNames = getFileNames(workingPath);
   if (fs.existsSync(fileNames.key) || nconf.get('AUTH_CERT')) {
     console.log('Certificates already exist, skipping certificate generation.');
     return cb();
@@ -26,9 +29,9 @@ module.exports = function (workingPath, info, cb) {
         { shortName: 'OU', value: info.connectionDomain},
         { shortName: 'O', value: 'auth0/ad-ldap-connector'}
       ], {
-        days: 365, 
-        algorithm: 'sha256', 
-        keySize:2048 
+        days: 365,
+        algorithm: 'sha256',
+        keySize:2048
       });
 
   fs.writeFileSync(fileNames.pem, pems.cert);


### PR DESCRIPTION
When running the server for the first time, the certificates are made in the current directory instead of the directory the app is installed in.  The app then attempts to load the certificates from the app directory, which results in an error when the app is started from a different directory.

This [gist](https://gist.github.com/spopezen/d65c96f4c14d7aee82bfe82e2aaa75b0) is an example of that error.