### PR TITLE
Avoid uncaughtException in troubleshoot.js when res is undefined

### DIFF
--- a/troubleshoot.js
+++ b/troubleshoot.js
@@ -87,7 +87,8 @@ async.series([
 				logger.failed('Error connecting to Auth0.');
 				if (err)
 					logger.error('  > Error: %s', JSON.stringify(err));
-				logger.error('  > Status: %s', res.statusCode);
+				if (res)
+					logger.error('  > Status: %s', res.statusCode);
 				if (body)
 					logger.error('  > Body: %s', body.replace(/\n$/, ''));
 			} else {


### PR DESCRIPTION
When testing connectivity to Auth0, if the script is unable to reach the test endpoint, then `res` will be undefined, and the attempt to log `res.statusCode` results in an `uncaughtException`. In consequence, the troubleshooting won't be completed successfully.

This PR makes sure to check for `res` before attempting to log `res.statusCode`.