### PR TITLE
fix add_certs on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules/*
 *.log
 cache.db/
 .DS_store*
+.vscode

--- a/lib/add_certs.js
+++ b/lib/add_certs.js
@@ -58,10 +58,13 @@ function readSystemCAs(cb) {
   switch(process.platform) {
     case 'win32':
       console.log('Reading CA certificates from Windows Store');
-      var winCa = require('win-ca');
+      var winCa = require('win-ca-ffi');
       var forge = require('node-forge');
-      var cas = winCa.all().map(function(ca){
-        return { pem: forge.pki.certificateToPem(ca) };
+      var moment = require('moment');
+      var cas = [];
+      winCa.each(['TRUSTEDPEOPLE', 'CA', 'ROOT'], function(ca){
+          if (moment(ca.validity.notAfter).isBefore()) { return; }
+          cas.push( { pem: forge.pki.certificateToPem(ca) });
       });
       cb(null, cas);
       break;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1094,6 +1094,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ffi/-/ffi-2.2.0.tgz",
       "integrity": "sha1-vxiwRmain3EiftVoldVDCvRwQvo=",
+      "optional": true,
       "requires": {
         "bindings": "1.2.1",
         "debug": "2.6.1",
@@ -2899,6 +2900,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ref-struct/-/ref-struct-1.1.0.tgz",
       "integrity": "sha1-XV7mWtQc78Olxf60BYcmHkee3BM=",
+      "optional": true,
       "requires": {
         "debug": "2.6.1",
         "ref": "1.3.5"
@@ -3910,11 +3912,12 @@
       "resolved": "https://registry.npmjs.org/win-ca/-/win-ca-1.0.0.tgz",
       "integrity": "sha1-ew0c1yJxLxC/FY9dmUqjlQevWTI=",
       "requires": {
-        "win-ca-ffi": "github:jfromaniello/win-ca#e2dbcec5b4e407f2066db1b0f6952ccc35328aab"
+        "win-ca-ffi": "github:jfromaniello/win-ca#f5a9fcd99fba90b4647b1f043c56fe970a971dd3"
       }
     },
     "win-ca-ffi": {
-      "version": "github:jfromaniello/win-ca#e2dbcec5b4e407f2066db1b0f6952ccc35328aab",
+      "version": "github:jfromaniello/win-ca#f5a9fcd99fba90b4647b1f043c56fe970a971dd3",
+      "optional": true,
       "requires": {
         "ffi": "2.2.0",
         "node-forge": "0.6.49"
@@ -3923,7 +3926,8 @@
         "node-forge": {
           "version": "0.6.49",
           "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.49.tgz",
-          "integrity": "sha1-8e6V1ddGI5OP4Z1piqWibVTS9g8="
+          "integrity": "sha1-8e6V1ddGI5OP4Z1piqWibVTS9g8=",
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "snyk": "^1.18.0"
   },
   "optionalDependencies": {
-    "win-ca-ffi": "github:jfromaniello/win-ca#copy-files"
+    "win-ca-ffi": "github:jfromaniello/win-ca#support-other-stores"
   },
   "engines": {
     "node": "^8"


### PR DESCRIPTION
This revert the previous behavior of reading certificates not only from ROOT but also from Certificate Authorities and Trusted People.