### PR TITLE
Queue simultaneous bind requests

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -48,14 +48,19 @@ function logger(userName) {
 }
 
 var Users = module.exports = function (disable_caching) {
+  var binder = ldap_clients.binder;
+
   this._base = nconf.get("LDAP_BASE");
   this._baseGroups = nconf.get("LDAP_BASE_GROUPS") || nconf.get("LDAP_BASE");
   this._client = ldap_clients.client;
-  this._binder = ldap_clients.binder;
+  this._bindQueue = async.queue(function(request, cb) {
+    binder.bind(request.dn, request.password, cb);
+  }, 1);
 
   if (typeof disable_caching === 'undefined' || !disable_caching) {
     this._groupsCache = require('./cache').groups;
   }
+
 };
 
 /**
@@ -72,7 +77,7 @@ var Users = module.exports = function (disable_caching) {
  */
 Users.prototype.validate = function (userName, password, callback) {
   var self = this;
-  var binder = this._binder;
+  var bindQueue = this._bindQueue;
 
   var log = logger(userName);
 
@@ -93,7 +98,7 @@ Users.prototype.validate = function (userName, password, callback) {
     log('Bind with DN "' + profile.dn.green + '"');
 
     //try bind by password
-    binder.bind(profile.dn, password, function (err) {
+    bindQueue.push({dn: profile.dn, password: password}, function (err) {
       if (err) {
         if (err instanceof ldap.InvalidCredentialsError) {
           var detailedError = getDetailedError(err);

--- a/lib/users.js
+++ b/lib/users.js
@@ -95,7 +95,7 @@ Users.prototype.validate = function (userName, password, callback) {
       return callback(new WrongPassword(profile));
     }
 
-    log('Bind with DN "' + profile.dn.green + '"');
+    log('Queueing bind with DN "' + profile.dn.green + '"');
 
     //try bind by password
     bindQueue.push({dn: profile.dn, password: password}, function (err) {

--- a/test/users.tests.js
+++ b/test/users.tests.js
@@ -64,6 +64,20 @@ describe('users', function () {
     });
   });
 
+  it('should be able ot validate multiple simultaneous requests', function (done) {
+    async.parallel([
+      function(cb) {
+        users.validate('john', password, cb);
+      },
+      function(cb) {
+        users.validate('john', password, cb);
+      },
+      function(cb) {
+        users.validate('john', password, cb);       
+      }],
+      done);
+  });
+
   describe('validate with username and password', function () {
     var profile;
 


### PR DESCRIPTION
Changes the behaviour to queue all calls to the `binder` to avoid race conditions when a Bind request is sent while another one is still in progress and the LDAP server rejects the operation.