### PR TITLE
Add primary groups search

### DIFF
--- a/lib/initConf.js
+++ b/lib/initConf.js
@@ -5,6 +5,7 @@ var defaults = {
   AUTHENTICATION:                       'FORM',
   LDAP_SEARCH_QUERY:                    '(&(objectCategory=person)(anr={0}))',
   LDAP_SEARCH_ALL_QUERY:                '(objectCategory=person)',
+  LDAP_SEARCH_PRIMARY_GROUPS:           '(member:1.2.840.113556.1.4.1941:={0})',
   LDAP_SEARCH_GROUPS:                   '(member:1.2.840.113556.1.4.1941:={0})',
   LDAP_USER_BY_NAME:                    '(sAMAccountName={0})',
   LDAP_NUMBER_OF_PARALLEL_BINDS:        1,

--- a/lib/users.js
+++ b/lib/users.js
@@ -473,6 +473,7 @@ Users.prototype._getAllGroupsADCached = function (profile, callback) {
         return callback(err);
       }
 
+      console.log('GROUPS', groups);
       graph.flatDeps(groups).forEach(function (fg) {
         self._groupsCache.put(fg.dn, JSON.stringify(fg), {
           ttl: 1000 * nconf.get('GROUPS_CACHE_SECONDS')
@@ -484,40 +485,85 @@ Users.prototype._getAllGroupsADCached = function (profile, callback) {
   });
 };
 
-Users.prototype._getAllGroupsAD = function (dn, callback) {
+/**
+ * ldapjs search using async/await syntax
+ * @param {*} baseGroups Defines the location in the directory from which the LDAP search for groups begins 
+ * @param {*} opts The options to pass to the ldapjs client
+ */
+function findGroups(client, baseGroups, opts) {
+  return new Promise(function(resolve, reject) {
+    client.search(baseGroups, opts, function(err, ldapEvents) {
+      if (err) {
+        return reject(err);
+      }
+
+      let entries = [];
+      ldapEvents.on('searchEntry', (entry) => {
+        entries.push(entry.object);
+      });
+
+      ldapEvents.on('error', (err) => {
+        return resolve(entries);
+      });
+
+      ldapEvents.on('end', (result) => {
+        if (result.status !== 0) {
+          console.log('Unexpected result on _getAllGroupsAD', result.status);
+        }
+        return resolve(entries);
+      });
+    });
+  });
+}
+
+Users.prototype._getAllGroupsAD = function(dn, callback) {
   var self = this;
-  var opts = {
-    scope: 'sub',
-    filter: nconf.get('LDAP_SEARCH_GROUPS').replace(/\{0\}/ig, dn),
-    attributes: _.uniq(['cn', 'dn', 'memberOf'].concat(nconf.get('GROUP_PROPERTIES'))),
-    timeLimit: nconf.get('GROUPS_TIMEOUT_SECONDS'),
-    derefAliases: nconf.get('GROUPS_DEREF_ALIASES')
-  };
 
   callback = cb(callback)
     .timeout(nconf.get('GROUPS_TIMEOUT_SECONDS') * 1000)
     .once();
 
-  self._client.search(self._baseGroups, opts, function (err, res) {
-    if (err) {
-      return callback(err);
-    }
-    var entries = [];
-
-    res.on('searchEntry', function (entry) {
-      entries.push(entry.object);
-    });
-
-    res.on('error', function (err) {
-      console.log('search groups', err.message);
-      callback(null, entries);
-    });
-
-    res.on('end', function (result) {
-      if (result.status !== 0) {
-        console.log('Unexpected result on _getAllGroupsAD', result.status);
+  async.parallel([
+    async function(cb) {
+      try {
+        console.info('gathering primary groups for', dn);
+        let primaryGroups = await findGroups(self._client, self._baseGroups, {
+          scope: 'sub',
+          filter: nconf.get('LDAP_SEARCH_PRIMARY_GROUPS').replace(/\{0\}/ig, dn),
+          attributes: _.uniq(['cn', 'dn', 'memberOf'].concat(nconf.get('GROUP_PROPERTIES'))),
+          timeLimit: nconf.get('GROUPS_TIMEOUT_SECONDS'),
+          derefAliases: nconf.get('GROUPS_DEREF_ALIASES')
+        });
+        return cb(null, primaryGroups);
+      } catch (err) {
+        console.error('failed during primary group search', err.message);
+        return cb(err);
       }
-      callback(null, entries);
-    });
+    },
+    async function(cb) {
+      try {
+        console.info('gathering secondary groups for', dn);
+        let secondaryGroups = await findGroups(self._client, self._baseGroups, {
+          scope: 'sub',
+          filter: nconf.get('LDAP_SEARCH_GROUPS').replace(/\{0\}/ig, dn),
+          attributes: _.uniq(['cn', 'dn', 'memberOf'].concat(nconf.get('GROUP_PROPERTIES'))),
+          timeLimit: nconf.get('GROUPS_TIMEOUT_SECONDS'),
+          derefAliases: nconf.get('GROUPS_DEREF_ALIASES')
+        });
+        return cb(null, secondaryGroups);
+      } catch (err) {
+        console.error('failed during secondary group search', err.message);
+        return cb(err);
+      }
+    }
+  ],
+  function(err, results) {
+    let entries = _.flatten(results);
+    if (err) {
+      console.log('search groups', err.message);
+      return callback(null, entries);
+    }
+
+    return callback(null, entries);
   });
-};
+}

--- a/test/users.tests.js
+++ b/test/users.tests.js
@@ -91,6 +91,9 @@ describe('users', function () {
     });
 
     it('should include groups', function () {
+      expect(profile.groups).to.include('Users');
+      expect(profile.groups).to.include('Domain Users');
+      expect(profile.groups).to.include('Recursive Group');
       expect(profile.groups).to.include('Administrators');
       expect(profile.groups).to.include('Domain Admins');
       expect(profile.groups).to.include('Denied RODC Password Replication Group');
@@ -125,6 +128,9 @@ describe('users', function () {
     });
 
     it('should include groups', function () {
+      expect(error.profile.groups).to.include('Users');
+      expect(error.profile.groups).to.include('Domain Users');
+      expect(error.profile.groups).to.include('Recursive Group');
       expect(error.profile.groups).to.include('Administrators');
       expect(error.profile.groups).to.include('Domain Admins');
       expect(error.profile.groups).to.include('Denied RODC Password Replication Group');
@@ -175,6 +181,9 @@ describe('users', function () {
     });
 
     it('should include groups', function () {
+      expect(profile.groups).to.include('Users');
+      expect(profile.groups).to.include('Domain Users');
+      expect(profile.groups).to.include('Recursive Group');
       expect(profile.groups).to.include('Administrators');
       expect(profile.groups).to.include('Domain Admins');
       expect(profile.groups).to.include('Denied RODC Password Replication Group');
@@ -206,6 +215,9 @@ describe('users', function () {
     });
 
     it('should include groups', function () {
+      expect(error.profile.groups).to.include('Users');
+      expect(error.profile.groups).to.include('Domain Users');
+      expect(error.profile.groups).to.include('Recursive Group');
       expect(error.profile.groups).to.include('Administrators');
       expect(error.profile.groups).to.include('Domain Admins');
       expect(error.profile.groups).to.include('Denied RODC Password Replication Group');


### PR DESCRIPTION
**DO NOT MERGE** - Work in progress - **DO NOT MERGE**

# Background
In certain situations we need to get **all** of the groups an user belongs to. Currently the `groups` array that is returned as part of the profile data does not include the primaryGroup for the user (or any of its parent groups).

# Overview
This PR adds a second stage to group lookup for retrieving the primary group information for the user.

