### PR TITLE
read all windows certificate stores in test_config.js

### DIFF
--- a/admin/test_config.js
+++ b/admin/test_config.js
@@ -97,10 +97,13 @@ module.exports = function (config, callback) {
       var cas;
 
       if (process.platform === 'win32') {
-        var winCa = require('win-ca');
+        var winca = require('win-ca-ffi');
         var forge = require('node-forge');
-        cas = winCa.all().map(function(ca){
-          return { pem: forge.pki.certificateToPem(ca) };
+        var moment = require('moment');
+        var cas = [];
+        winca.each(['TRUSTEDPEOPLE', 'CA', 'ROOT'], function(ca){
+          if (moment(ca.validity.notAfter).isBefore()) { return; }
+          cas.push(forge.pki.certificateToPem(ca));
         });
       } else {
         cas = https.globalAgent.options.ca;


### PR DESCRIPTION
The connector was reading these 3 stores, but the configuration test was reading just one. This was tested on a windows machine.