### PR TITLE
Add support for groups in search results

### DIFF
--- a/lib/initConf.js
+++ b/lib/initConf.js
@@ -4,6 +4,7 @@ var defaults = {
   SESSION_SECRET:                       'a1b2c3d4567',
   AUTHENTICATION:                       'FORM',
   LDAP_SEARCH_QUERY:                    '(&(objectCategory=person)(anr={0}))',
+  LDAP_SEARCH_RESULTS_OMIT_GROUPS:      true,
   LDAP_SEARCH_ALL_QUERY:                '(objectCategory=person)',
   LDAP_SEARCH_LIST_GROUPS_QUERY:        '(objectCategory=group)',
   LDAP_SEARCH_GROUPS:                   '(member:1.2.840.113556.1.4.1941:={0})',

--- a/lib/users.js
+++ b/lib/users.js
@@ -59,8 +59,15 @@ var Users = module.exports = function (disable_caching) {
 
   if (typeof disable_caching === 'undefined' || !disable_caching) {
     this._groupsCache = require('./cache').groups;
+  } else {
+    // mock cache that does nothing
+    this._groupsCache = {
+      get: function (dn, cb) {
+        cb();
+      },
+      put: function() { }    
+    };
   }
-
 };
 
 /**
@@ -361,7 +368,7 @@ Users.prototype.list = function (search, options, callback) {
       }
 
       async.map(entries, function (e, done) {
-        self.enrichProfile(e, true, done);
+        self.enrichProfile(e, nconf.get('LDAP_SEARCH_RESULTS_OMIT_GROUPS'), done);
       }, callback);
     }
 


### PR DESCRIPTION
Via the new `LDAP_SEARCH_RESULTS_OMIT_GROUPS` env variable.