### PR TITLE
Add logging for ANONYMOUS_SEARCH_ENABLED

### DIFF
--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -26,6 +26,13 @@ function createConnection () {
 
 function initializeConnection () {
   var connection = createConnection();
+  if (nconf.get('ANONYMOUS_SEARCH_ENABLED')) {
+    var proxiedSearch = connection.search;
+    connection.search = function () {
+      console.log("Anonymous search");
+      return proxiedSearch.apply(this, arguments);
+    }
+  }
 
   connection.on('close', function () {
     console.error('Connection to ldap was closed.');


### PR DESCRIPTION
It would be useful to have some visibility in the logs when `ANONYMOUS_SEARCH_ENABLED` is set to `true`.

This PR adds a logs every time an anonymous search is made.

I could see this being a bit too verbose, so maybe it would make sense just to log it once when creating the ldap client, and perhaps when the troubleshooter runs as well. 

Happy to chat about it.