### PR TITLE
properly parse objectsid from windows active directories

### DIFF
--- a/lib/objectsid.js
+++ b/lib/objectsid.js
@@ -1,0 +1,38 @@
+const binary = require('binary');
+
+//This logic was extracted from this implementation:
+// https://github.com/pfmooney/node-ldapjs-mangle-proxy/blob/master/lib/objectsid.js
+
+function outputType(type) {
+  var buf = new Buffer(6);
+  type.copy(buf, 0);
+  var output = 0;
+  for (var i = 0; i < 6; i++) {
+    output = output << 8;
+    output = output | buf[i];
+  }
+  return output;
+}
+
+module.exports.parse = function(buffer) {
+  if (!Buffer.isBuffer(buffer) || !buffer.length) {
+    return;
+  }
+  try {
+    const parser = binary.parse(buffer)
+    .word8lu('version')
+    .word8lu('fields')
+    .buffer('type', 6)
+    .loop(function (end, vars) {
+      vars.sid = vars.sid || new Array();
+      vars.sid.push(this.word32lu('sid_field').vars.sid_field);
+      if (vars.sid.length >= vars.fields) {
+        end();
+      }
+    });
+    const { version, type, sid } = parser.vars;
+    return ['S', version, outputType(type), ...sid].join('-');
+  } catch(err) {
+    return;
+  }
+};

--- a/lib/users.js
+++ b/lib/users.js
@@ -16,6 +16,7 @@ var WrongUsername = require('./errors/WrongUsername');
 var UnexpectedError        = require('./errors/UnexpectedError');
 var InsufficientAccessRightsError = require('./errors/InsufficientAccessRightsError');
 var PasswordComplexityError = require('./errors/PasswordComplexityError');
+var objectsid = require('./objectsid');
 
 var profileMapper;
 
@@ -280,6 +281,9 @@ function getProperObject(entry) {
         break;
       case 'objectGUID':
         item = formatGuid(buf[0]);
+        break;
+      case 'objectSid':
+        item = objectsid.parse(buf[0]);
         break;
       default:
         item = val;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-ldap-connector",
-  "version": "5.0.7",
+  "version": "5.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@auth0/thumbprint": "0.0.6",
     "archiver": "^3.0.0",
     "async": "~0.2.9",
+    "binary": "^0.3.0",
     "body-parser": "^1.18.3",
     "cb": "~0.1.0",
     "colors": "~0.6.0-1",

--- a/test/objectSID.tests.js
+++ b/test/objectSID.tests.js
@@ -1,0 +1,28 @@
+const { assert } = require('chai');
+const objectSid = require('../lib/objectsid');
+
+describe('objectsid parsing', function() {
+
+  it('should work', function() {
+    const buffer = new Buffer('01 05 00 00 00 00 00 05 15 00 00 00 75 19 89 A4 FC B3 64 B5 92 2C 56 92 92 23 00 00'.split(' ').map(n => parseInt(n, 16)))
+    const expected = 'S-1-5-21-2760448373-3043275772-2455121042-9106';
+    assert.equal(
+      objectSid.parse(buffer),
+      expected
+    );
+  });
+
+  it('should return undefined when is not a buffer', function() {
+    assert.equal(
+      objectSid.parse({}),
+      undefined
+    );
+  });
+
+  it('should return undefined when buffer is empty', function() {
+    assert.equal(
+      objectSid.parse(Buffer.from([])),
+      undefined
+    );
+  });
+});


### PR DESCRIPTION
### Description

Parse `objectSid` attribute from Windows Active Directory.

### References

https://auth0team.atlassian.net/browse/ESD-5123

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
- [x] This change was tested using Active Directory

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
