### PR TITLE
Build & run AD-LDAP Connector as a Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:10
+
+# Create app directory
+WORKDIR /opt/auth0
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+CMD [ "node", "server.js" ]


### PR DESCRIPTION
### Description
Added a Dockerfile to enable building and running the ad-ldap connector as a Docker container.


### References
Here's a sample docker-compose.yml for bringing up the container via docker-compose:

```
version: '3'

services:
  openldap:
    image: "osixia/openldap:${LDAP_SERVER_VERSION}"
    container_name: openldap
    env_file:
      - ldap-server.env
    restart: always
    tty: true
    stdin_open: true
    volumes:
      - /var/lib/ldap
      - /etc/ldap/slapd.d
      - /container/service/slapd/assets/certs/
    ports:
      - 389:389
      - 636:636

  auth0-adldap-connector:
    image: auth0/ad-ldap-connector:5.0.10
    container_name: adldap-connector
    environment: 
      - PROVISIONING_TICKET=https://{tenant}.auth0.com/p/ad/{token}
      - LDAP_URL=ldap://ldap
      - LDAP_BASE=dc=example,dc=org
      - LDAP_BIND_USER=cn=admin,dc=example,dc=org
      - LDAP_BIND_PASSWORD=admin
      - LDAP_USER_BY_NAME=(cn={0})
    volumes:
      - certs-data:/opt/auth0-adldap/certs
    depends_on:
      - openldap


volumes:
  certs-data:
    driver: local

```

### Testing
Tested successfully on an Ubuntu 18.04 machine. Other platforms will need to be tested.

### Checklist

- [no] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [yes] All active GitHub checks for tests, formatting, and security are passing
- [yes] The correct base branch is being used, if not `master`
