### PR TITLE
[IUM-1171] Update ws_validator to use expiresIn param for JWT signing instead of deprecated expiresInMinutes param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-ldap-connector",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -48,6 +48,51 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.1.tgz",
       "integrity": "sha512-tLnujxFtfH7F+i5ghUfgGlJsvyCKvUnSMFMlWybFdX9/DdX8svb4Zwx1gV0gkkVCHXtmPSetoAR3QlKfOld6Tw==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
     "@snyk/cli-interface": {
@@ -2304,6 +2349,16 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2934,6 +2989,12 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-path-inside": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
@@ -3108,6 +3169,12 @@
           "dev": true
         }
       }
+    },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
     },
     "jwa": {
       "version": "1.4.1",
@@ -3723,6 +3790,12 @@
         }
       }
     },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
@@ -3864,6 +3937,36 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -4387,6 +4490,12 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -4566,6 +4675,17 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -4751,6 +4871,15 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-alpn": {
       "version": "1.0.0",
@@ -4973,6 +5102,44 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.1.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "slash": {
       "version": "3.0.0",
@@ -6510,6 +6677,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "bump-version": "^0.5.0",
     "chai": "~1.7.2",
     "mocha": "^6.1.4",
+    "proxyquire": "^2.1.3",
+    "sinon": "^9.0.3",
     "snyk": "^1.381.1"
   },
   "optionalDependencies": {},

--- a/test/ws_validator.tests.js
+++ b/test/ws_validator.tests.js
@@ -1,0 +1,137 @@
+const { expect } = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
+var jwt = require('jsonwebtoken');
+
+
+let mockWebSocketInstance;
+
+class MockWebSocket {
+
+  constructor () {
+    this.handlers = {};
+    mockWebSocketInstance = this;
+  }
+
+  getHandlers (eventType) {
+    this.handlers[eventType] = this.handlers[eventType] || [];
+
+    return this.handlers[eventType];
+  }
+
+  on (eventType, handler) {
+    this.getHandlers(eventType).push(handler);
+
+    return this;
+  }
+
+  emit (eventType, event) {
+    this.getHandlers(eventType).forEach((handler) => handler(event));
+  }
+
+  send (event) {
+    this.emit('send', event)
+  }
+
+  reply () {}
+}
+
+class MockUsers {}
+
+const mockNconf = {
+  values: {},
+  get: (key) => mockNconf.values[key],
+  set: (key, value) => {
+    mockNconf.values[key] = value;
+  },
+  '@global': true,
+}
+
+const cert = `-----BEGIN CERTIFICATE-----
+MIIC1TCCAb2gAwIBAgIJAIbNqgTtQOiBMA0GCSqGSIb3DQEBBQUAMBoxGDAWBgNV
+BAMTD3d3dy5leGFtcGxlLmNvbTAeFw0yMDA5MDgxNjE3MjVaFw0zMDA5MDYxNjE3
+MjVaMBoxGDAWBgNVBAMTD3d3dy5leGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBALQXH/0vWagNLdXH30J7YjjbiLCrRTFX20JG878DXxM5
+MhxU5UOqH53MrDl5M47ZMpKq2Vih0E62FxtkjlOhO1RotqUWhmM/z7fpk1Cf1GjG
+jb4e9xRxSTP40ZDjrnGxBPTmyy6KxC1OnsdraxxaGg5p+63icaKtTx/Ofj2efmH4
+OggY7MSb04jDvSmanTi9eTfCW0uiwMdiwtmFEoDrgEB5Xy1yOEo/+3i02M7Aub2H
+RV5Utd22VGPjWsUlJ30PjzxrXCygGIQFmXUMgKR3QVJzT5XXEJa4wILcfqWCuPB1
+8sepoxAGzIUMCDV7ReIiZCoPGcPb19e18tloLIJcpdkCAwEAAaMeMBwwGgYDVR0R
+BBMwEYIPd3d3LmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBBQUAA4IBAQBaWbAZ85s/
+YLMbiXNnQCkSWKazCSyFax/mD9ymx1asiDHScNn2NwTwDoQaMzeDuQL36Cggt/Ty
+ClJqvmkS2992sfmDQzWzMTD5zrSU4tODAT1S+riPl/gvELj6BAZ+phLLbR6cxQi8
+C6uhavQZOgzIw3kD4XrrCOzexKqs2LxhxPgJ3ZqtQLFbmWhdj0yF3XiITPpyFNzR
+xm+DIK8LwSOcoCLDkoyAV86uX8wJ2Xwg7CMVUZ57fXg8YOgNbcOJKEz4AHedxwN7
+OB/Jb61nFebraXicZQEnI9/6jukU04M5nBuGMelHCtu+kS3eWGLwzuW99arJXyrJ
+9NS1m6MEVq5Z
+-----END CERTIFICATE-----
+`;
+
+const key = `-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAtBcf/S9ZqA0t1cffQntiONuIsKtFMVfbQkbzvwNfEzkyHFTl
+Q6ofncysOXkzjtkykqrZWKHQTrYXG2SOU6E7VGi2pRaGYz/Pt+mTUJ/UaMaNvh73
+FHFJM/jRkOOucbEE9ObLLorELU6ex2trHFoaDmn7reJxoq1PH85+PZ5+Yfg6CBjs
+xJvTiMO9KZqdOL15N8JbS6LAx2LC2YUSgOuAQHlfLXI4Sj/7eLTYzsC5vYdFXlS1
+3bZUY+NaxSUnfQ+PPGtcLKAYhAWZdQyApHdBUnNPldcQlrjAgtx+pYK48HXyx6mj
+EAbMhQwINXtF4iJkKg8Zw9vX17Xy2Wgsglyl2QIDAQABAoIBAF959xqq1NSUkB1L
+xuCfO1a7hP9s/dUIKBU+OpGlPu2ZICkHFTlHY1Wsog4iZKQyIG7Dp1EnEKH6Rcvf
+Btntm9/HWDWz+HF77isp6VEQO3OE+La4AfRTjyS/oJM5Mk3SNLeF+GhnZ1RB30oI
+eBPi7PeBVs48RFSjn1RUjHcspQJYzPHEGEonE6vKi8MDcXxS12eVKMwmSYedyVNR
+1wjWVoIqsry6BEo/TEaL+TT+UgarWeIXz//707MZyBH7JxhCUv6bOxUYyAz97vmS
+X8JZ5T7LcT/t4uTckdMr6//iXU1+L9YqryGiILwEVPGZEQOxiFausPA512aD38v1
+4xWTK8UCgYEA2coUP8S7kAyVh4SkgTaWXfFevWsQY6ulD88z3mO0eK82v8n880jB
+n2Lqx5vutmlAKOAaxyO/2AS8ZjlrwJQFGjnoswzA+vVjrPow+WcuxhsYP7Ufl/Vs
+tWbQdTQ7c1TiuTJmjp7+u7DOfCA0QDx8yDYHWxe4VwMcXWyMZe+eXgMCgYEA06/P
+EOhGE1JX9bGUyEIpyl07qEz2FYlhoxZ+x3nQFO/CoIM+zE1Gsr+PZ74uexh4HnMe
+HiXtSv362W71QkBr/gotxOviWVIGE6bTtVuGGGCTDQYOeTTlZw5rC6lj4V4ZvU4R
+o3sb5cjKRK5ARp6bQchQ3gf1vHbTZ7r2FhtlI/MCgYBNrOMX80SqFbLnCInbg+qR
+StrtV9galEdkohPvx0PAn005jgLnihV0kUUHODglWtiFO5iRWdC8bMP8+ZHSt3gy
+aGD0KyJQ32BTe1AoQ4LNKTC22BSSj/fbovXKN3zUn3vVbYJib5aOvnqGjr3UAz7F
+8W8iMA2RCwz8zRAt8w5anQKBgBR40iuuauh/dCY8sEjVrTj230gdeUcH7Dtbd5NP
+AoKj1Uy0pKQZbRboU7QSvmgFK8i2FVmRDWvNOC9C/dEUbd05mseKkG9W8WOBJMRL
+P6Kn5FDEHy41oWHgERYloZUwBok6PZZz13TXgEg4Gds6h4VLHBb86hT54OQNPrNQ
+nu1lAoGAC+EHr+9hBFNz6fQWuQivMMqmUYTkNHPgFupf5xTRyq7euMms/1RAcjaE
+ifQQICxPn+sIprdshYSGD2xLa7LuY9KwI2WpenLxVFSEXizEwCwa+NquUa4C+fhk
+xg2fno4Ifa9Qc7w5ywI7LpbyRXNfAbvcgUWlCGDbekS+SzgosEc=
+-----END RSA PRIVATE KEY-----
+`;
+
+describe('ws_validator', () => {
+  mockNconf.set('LDAP_URL', 'ldap://ds.example.com:389/dc=example,dc=com');
+  mockNconf.set('SSL_ENABLE_EMPTY_SUBJECT', true);
+  mockNconf.set('LDAP_BIND_PASSWORD', 'abc123');
+  mockNconf.set('AUTH_CERT_KEY', key);
+  mockNconf.set('AUTH_CERT', cert);
+  mockNconf.set('AD_HUB', 'http://test.io');
+
+
+  const wsValidator = proxyquire('../ws_validator', {
+    'ws': MockWebSocket,
+    'nconf': mockNconf,
+    './lib/users': MockUsers,
+  });
+  
+  it('authenticate_connector', () => {
+    const testStart = Math.floor(Date.now() / 1000);
+
+    let authenticationEvent;
+
+    mockWebSocketInstance.on('send', (event) => {
+      authenticationEvent = JSON.parse(event);
+    });
+
+    mockWebSocketInstance.emit('open');
+    console.log(typeof authenticationEvent);
+
+    expect(authenticationEvent).to.be.ok;
+    expect(authenticationEvent.n).to.equal('authenticate');
+    expect(authenticationEvent.p).to.be.ok;
+    expect(authenticationEvent.p.jwt).to.be.ok;
+    expect(authenticationEvent.p.jwt).to.be.ok;
+
+    const decoded = jwt.decode(authenticationEvent.p.jwt)
+    expect(decoded).to.be.ok;
+    expect(decoded.exp).to.be.ok;
+    expect(decoded.exp - testStart).to.equal(60);
+  });
+
+});

--- a/test/ws_validator.tests.js
+++ b/test/ws_validator.tests.js
@@ -120,7 +120,6 @@ describe('ws_validator', () => {
     });
 
     mockWebSocketInstance.emit('open');
-    console.log(typeof authenticationEvent);
 
     expect(authenticationEvent).to.be.ok;
     expect(authenticationEvent.n).to.equal('authenticate');

--- a/ws_validator.js
+++ b/ws_validator.js
@@ -334,7 +334,7 @@ function setupWebsocket() {
 
     var token = jwt.sign({}, cert.key, {
       algorithm: 'RS256',
-      expiresInMinutes: 1,
+      expiresIn: '1m',
       issuer: nconf.get('CONNECTION'),
       audience: nconf.get('REALM'),
       "http://schemas.auth0.com/ad-ldap-connector/capabilites": defaultCapabilities


### PR DESCRIPTION
### Description

Previously we were passing `expiresInMinutes` ([deprecated](https://github.com/auth0/node-jsonwebtoken/issues/166#issuecomment-172633653)) to jwt.sign. Instead we should instead pass `expiresIn: '1m'` to avoid generating a deprecation warning log. 


### References

- [IUM-1171](https://auth0team.atlassian.net/browse/IUM-1171)
- [ESD-8527](https://auth0team.atlassian.net/browse/ESD-8527)

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
