### PR TITLE
[ESD-9997] Improving Anonymous LDAP Search detection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Fixes
 Fix anonymous LDAP search detection logic.
-
-## [Unreleased]
 Add CHANGELOG.md
 
 ## [5.0.13]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.0.14]
+
+### Fixes
+Fix anonymous LDAP search detection logic.
+
 ## [Unreleased]
 Add CHANGELOG.md
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-ldap-connector",
-  "version": "5.0.13",
+  "version": "5.0.14",
   "description": "ADLDAP Federation Connector",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
The current implementation doesn't specify the limit of users to be returned by the search condition, so the LDAP server will try to return all the users matching `(objectclass=person)`, which is basically all the users in the directory.

Proposed changes:

* Set `sizeLimit: 1` to avoid `TimeLimitExceededError` errors.
* And, enable anonymous access when server returns `SizeLimitExceededError` (that means that there are more than one entry matching the search).

![image](https://user-images.githubusercontent.com/178506/98592949-38a7aa00-22b1-11eb-9158-5c41012afe4c.png)

https://auth0team.atlassian.net/browse/ESD-9997
