### PR TITLE
Limit ldap heartbeat search query scope and size

### DIFF
--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -28,7 +28,12 @@ function initializeConnection () {
   });
 
   connection.heartbeat = function (callback) {
-    connection.search('', '(objectclass=*)', function (err, res) {
+    const searchOpts = {
+      filter: '(objectclass=person)',
+      scope: 'sub',
+      sizeLimit: 1
+    };
+    connection.search(nconf.get('LDAP_BASE'), searchOpts , function (err, res) {
       if (err) {
         return callback(err);
       }
@@ -42,7 +47,12 @@ function initializeConnection () {
       res.once('error', function(err) {
         client.removeAllListeners('end');
         clearTimeout(abort);
-        callback(err);
+        // if there are more than one entry matching the search, the server returns the one entry and a SizeLimitExceededError error
+        if (err.name === 'SizeLimitExceededError') {
+          callback();
+        } else {
+          callback(err);
+        }
       }).once('end', function () {
         client.removeAllListeners('error');
         clearTimeout(abort);


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The currently used search query for the ldap heartbeats (`connection.search('', '(objectclass=*)'`) leads to `ad-ldap-connector` instances timing out during heartbeats when integrated with moderately-large production AD deployments.

This PR attemps addressing this by taking an approach similar to the recent Anonymous Search detection logic improvement: https://github.com/auth0/ad-ldap-connector/commit/0c83350da52c019958476b395df562f194783228

### References

https://github.com/auth0/ad-ldap-connector/commit/0c83350da52c019958476b395df562f194783228

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
