### PR TITLE
Add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,13 @@ npm-debug.log
 config.json
 config.json*
 config*.json
+config.tar.gz
 installer/output/*
 installer/adldap.msi
 installer/directory.wxs
 installer/log.log
 node_modules/*
+profileMapper.js
 *.log
 cache.db/
 .DS_store*

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,84 @@
+# Using the AD/LDAP Connector with Docker
+
+The AD/LDAP Connector agent can only run in a single host. Therefore, Docker is a perfect tool to run and manage multiple connectors for use cases where you have lots AD/LDAP Connections in Auth0 and associated AD/LDAP directories (or OUs within a directory) to connect to. For example, you may have user identities that are divided up by B2B customer spread across individual directories or OUs.
+
+The `./docker-auth0-adldap.sh` script can be used to perform several workflows to manage one or more AD/LDAP Connector instances as Docker containers.
+
+## Environment
+
+First, set a few variables that will be used with all of the commands:
+
+```bash
+IMAGE_NAME=auth0-ad-ldap-connector
+CONNECTOR_NAME=acme-ldap
+```
+
+* `IMAGE_NAME`: the name of the Docker image that will be used to create the Connector containers
+* `CONNECTOR_NAME`: a name that identifies the Connector, which, as a convention can be the name of the associated Auth0 [AD/LDAP Connection](https://auth0.com/docs/connections/enterprise/active-directory-ldap).
+
+## Build a local AD/LDAP Connector image
+
+If you're not using a remote image library, you can build the image locally using the [Dockerfile](./Dockerfile):
+
+```bash
+./docker-auth0-adldap.sh build-image ${IMAGE_NAME}
+```
+
+> NOTE: If the image already exists, it will be removed and replaced by the new one.
+
+## Run the first Connector container for your AD/LDAP Connection
+
+The very first Connector container will "bootstrap" the associated AD/LDAP Connection such that no other Connector instance can use the provisioning URL again. This is done via the self-signed certificate that a Connector generates and registers with the Auth0 connection.
+
+To set this up, first create a `config.json` file that contains the provisioning ticket URL of the associated AD/LDAP Connection in Auth0 as well as the `LDAP_`* configuration needed to communicate with the associated AD/LDAP server:
+
+```json
+{
+  "PROVISIONING_TICKET": "AD_LDAP_CONNECTION_PROVISIONING_TICKET_URL",
+  "LDAP_URL": "ldap://ldap.forumsys.com",
+  "LDAP_BASE": "dc=example,dc=com",
+  "LDAP_USER_BY_NAME": "(uid={0})",
+  "LDAP_SEARCH_QUERY": "(&(objectClass=person)(uid={0}))",
+  "LDAP_SEARCH_ALL_QUERY": "(objectClass=person)"  
+}
+```
+
+> NOTE: The above `LDAP_`* configuration works with a [free online LDAP test server](https://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/), which makes for easy testing of the Connector without having to stand up your own LDAP server. You may need to use different AD/LDAP Connector [configuration options](https://auth0.com/docs/extensions/ad-ldap-connector/ad-ldap-connector-config-file-schema) (such as `LDAP_BIND_USER` and `LDAP_BIND_PASSWORD`), depending on the requirements of your AD/LDAP server.
+
+Next, create a `profileMapper.js` file in order to [map the desired LDAP attributes to the Auth0 user profile](https://auth0.com/docs/extensions/ad-ldap-connector/map-ad-ldap-profile-attributes-to-auth0) for the given AD/LDAP Connection.
+
+With those files ready, bootstrap and fire up the first Connector:
+
+```bash
+./docker-auth0-adldap.sh run-first-connector ${IMAGE_NAME} ${CONNECTOR_NAME}
+```
+
+For development, you may only need a single Connector container running, so the above is sufficient. However, if you want to run multiple Connector instances for [high availability](https://auth0.com/docs/extensions/ad-ldap-connector/ad-ldap-high-availability), keep reading.
+
+## Export Connector configuration
+
+Before you can run another Connector container that will be associated with the _same_ AD/LDAP Connection in Auth0, you need to capture the configuration from the first container:
+
+```bash
+./docker-auth0-adldap.sh export-connector-config ${IMAGE_NAME} ${CONNECTOR_NAME}
+```
+
+This will generate a `config.tar.gz` file, which you can use with the next command.
+
+## Run additional Connector containers for your AD/LDAP Connection
+
+With the configuration exported, you can run this command to create and start an additional Connector container:
+
+```bash
+./docker-auth0-adldap.sh run-additional-connector ${IMAGE_NAME} ${CONNECTOR_NAME}-ha1
+```
+
+This sub-command takes the same arguments as `run-first-connector`. However, if you are running the additional container in the same Docker instance, you will need to provide a unique suffix (like `-ha1` shown above) so a unique container name is generated.
+
+## Kill all Connector containers
+
+If you simply simply need to wipe out all Connector containers (running or not) in the Docker instance that are associated with your Connector image, you can run this command:
+
+```bash
+./docker-auth0-adldap.sh kill-connectors ${IMAGE_NAME}
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:14
+
+ENV AD_LDAP_CONNECTOR_VERSION=6.1.1
+
+# Create app directory
+WORKDIR /opt/auth0-adldap
+
+# Download and install the Connector
+RUN depsRuntime=" \
+    # tools \
+    vim \
+    curl \
+  " \
+  set -x \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends $depsRuntime \
+  && curl -Lo /tmp/adldap.tar.gz https://github.com/auth0/ad-ldap-connector/archive/v$AD_LDAP_CONNECTOR_VERSION.tar.gz \
+  && tar -xzf /tmp/adldap.tar.gz -C /opt/auth0-adldap --strip-components=1 \
+  && npm install
+
+CMD [ "node", "server.js" ]

--- a/docker-auth0-adldap.sh
+++ b/docker-auth0-adldap.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+ensure_param () {
+  local PARAM_NAME=$1
+  local PARAM_VALUE=${!PARAM_NAME}
+
+  if [ -z "${PARAM_VALUE}" ]; then
+    echo "Missing parameter: ${PARAM_NAME}"
+    exit 1
+  fi
+  echo "${PARAM_NAME}: ${PARAM_VALUE}"  
+}
+
+ensure_file () {
+  local FILE_PATH=$1
+  local FILE_FRIENDLY_NAME=$2
+
+  if [ ! -f "${FILE_PATH}" ]; then
+    echo "Missing ${FILE_FRIENDLY_NAME} file: ${FILE_PATH}"
+    exit 1
+  fi
+  echo "Using ${FILE_FRIENDLY_NAME} file: ${FILE_PATH}"
+}
+
+generate_container_name () {
+  CONTAINER_NAME=${IMAGE_NAME}_${CONNECTOR_NAME}
+  echo "CONTAINER_NAME: ${CONTAINER_NAME}"
+}
+
+SUB_COMMAND=$1
+
+case ${SUB_COMMAND} in
+
+  build-image)
+    echo "Build AD/LDAP Connector image:"
+    
+    IMAGE_NAME=$2
+    ensure_param "IMAGE_NAME"
+
+    echo "Removing existing image (if it exists)..."
+    docker image rm --force ${IMAGE_NAME}
+
+    echo "Building new image..."
+    docker build -t ${IMAGE_NAME} .
+    ;;
+
+  run-first-connector)
+    echo "Run first Connector container for a given Auth0 AD/LDAP Connection:"
+    
+    IMAGE_NAME=$2
+    ensure_param "IMAGE_NAME"
+    CONNECTOR_NAME=$3
+    ensure_param "CONNECTOR_NAME"
+    generate_container_name
+
+    ensure_file "./config.json" "Config"
+    ensure_file "./profileMapper.js" "Profile Mapper"
+
+    echo Creating AD/LDAP Connector container with name "${CONTAINER_NAME}"... 
+    docker create --name ${CONTAINER_NAME} ${IMAGE_NAME}
+
+    echo Copying config files to container...
+    docker cp ./config.json ${CONTAINER_NAME}:/opt/auth0-adldap/
+    docker cp ./profileMapper.js ${CONTAINER_NAME}:/opt/auth0-adldap/lib
+
+    echo Starting container...
+    docker start ${CONTAINER_NAME}
+
+    echo Tailing container logs...
+    docker logs -f ${CONTAINER_NAME}
+    ;;
+
+  export-connector-config)
+    echo "Export config files from AD/LDAP Connector container:"
+
+    IMAGE_NAME=$2
+    ensure_param "IMAGE_NAME"
+    CONNECTOR_NAME=$3
+    ensure_param "CONNECTOR_NAME"
+    generate_container_name
+
+    echo Creating config archive on container...
+    docker exec -it $CONTAINER_NAME tar -czvf config.tar.gz config.json lib/profileMapper.js certs/cert.key certs/cert.pem
+
+    echo Copying config archive from container...
+    docker cp $CONTAINER_NAME:/opt/auth0-adldap/config.tar.gz ./
+
+    echo Removing config archive from container...
+    docker exec -it $CONTAINER_NAME rm config.tar.gz
+    ;;
+
+  run-additional-connector)
+    echo "Run additional Connector container for a given Auth0 AD/LDAP Connection:"
+
+    IMAGE_NAME=$2
+    ensure_param "IMAGE_NAME"
+    CONNECTOR_NAME=$3
+    ensure_param "CONNECTOR_NAME"
+    generate_container_name
+
+    ensure_file "./config.tar.gz" "Config Archive"
+
+    echo Creating AD/LDAP Connector container with name "${CONTAINER_NAME}"... 
+    docker create --name ${CONTAINER_NAME} ${IMAGE_NAME}
+
+    echo Copying config archive to container...
+    docker cp ./config.tar.gz ${CONTAINER_NAME}:/opt/auth0-adldap/
+
+    echo Starting container...
+    docker start ${CONTAINER_NAME}
+
+    echo Extracting config archive...
+    docker exec ${CONTAINER_NAME} tar -xzvf config.tar.gz
+
+    echo Restarting container...
+    docker restart ${CONTAINER_NAME}
+
+    echo Tailing container logs...
+    docker logs -f ${CONTAINER_NAME}
+    ;;
+
+  kill-connectors)
+    echo "Remove all Connector containers:":
+
+    IMAGE_NAME=$2
+    ensure_param "IMAGE_NAME"
+
+    docker rm $(docker stop $(docker ps -a -q --filter ancestor=${IMAGE_NAME} --format="{{.ID}}"))
+    ;;
+
+  *)
+    echo "Command not supported. See DOCKER.md for usgae."
+    exit 1
+    ;;
+
+esac


### PR DESCRIPTION
Includes a script tool for useful Docker workflows

### Description

The AD/LDAP Connector agent can only run in a single host. Therefore, Docker is a perfect tool to run and manage multiple Connectors for use cases where you have lots AD/LDAP Connections in Auth0 and associated AD/LDAP directories (or OUs within a directory) to connect to. For example, you may have user identities that are divided up by B2B customer spread across individual directories or OUs.

The `docker-auth0-adldap.sh` script can be used to perform several workflows to manage one or more AD/LDAP Connector instances as Docker containers.

### References

- [non-Windows install process](https://auth0.com/docs/extensions/ad-ldap-connector/install-configure-ad-ldap-connector) (scroll down to "Install the connector for other platforms" section)

### Testing

No code changes have been made. This PR simply wraps the non-Windows install process in a `Dockerfile` that uses an Ubuntu+Node.js base image and provides a script tool to build the image and deploy and manage containers.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
