### PR TITLE
IUM-1941: Fix TLS version in update connector powershell script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [6.1.4]
+
+### Fixes
+Use TLS 1.2 protocol in connector updater script for Windows
+
 ## [6.1.3]
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-[![Build Status](https://travis-ci.org/auth0/ad-ldap-connector.svg?branch=master)](https://travis-ci.org/auth0/ad-ldap-connector)
-
 # Auth0 AD/LDAP Connector
 
 The __AD/LDAP Connector (1)__, is a bridge between your __Active Directory (2)__  and the __Auth0 Service (3)__. It runs on Windows, Mac and Linux. This bridge is necessary because AD is typically locked down to your internal network, and Auth0 is as cloud service running on a completely different context.
 
-<img src="https://docs.google.com/drawings/d/1X30jQAsatQTibLXgxKgDanbCH1RJ9ZAfoDmHV33jdBY/pub?w=630&amp;h=526">
+![](https://images.ctfassets.net/cdy7uua7fh8z/1xMpdHrtor0TR7F1gZ96zL/130e13f59b728fe14e00f1815b90103f/ldap-connect.png)
 
 You can install multiple instances of the connector for high availability and load balancing. Also, all connections are out-bound: from the connector to the Auth0 Server, so in general no changes to the firewall need to be applied.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-ldap-connector",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-ldap-connector",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "ADLDAP Federation Connector",
   "main": "server.js",
   "scripts": {

--- a/update-connector.ps1
+++ b/update-connector.ps1
@@ -60,6 +60,7 @@ If (Test-Path $packageLocation){
 }
 
 # Get latest version.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12  # TLS 1.0 and 1.1 are no longer supported
 $latest = Invoke-RestMethod -Uri "https://cdn.auth0.com/connector/windows/latest.json" -Method Get;
 $latestVersion = $latest.version
 $latestUrl =  $latest.url


### PR DESCRIPTION
### Description

Our CDN supports only TLS 1.2 and up. On some Windows version, the Powershell download protocol defaults to an older TLS version, thus causing a SSL tunnel failure at download time. 

### References

Link to original issue: [IUM-1941](https://auth0team.atlassian.net/browse/IUM-1941)

### Testing

This fix was tested by a DSE on his VM reproducing the problem.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
