### PR TITLE
updates github package ref to https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [6.1.5]
+### Fixes
+Fix installer creation
+
 ## [6.1.4]
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-ldap-connector",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3962,8 +3962,8 @@
       }
     },
     "passport-ssl-certificate": {
-      "version": "git://github.com/jaredhanson/passport-ssl-certificate.git#826c16d040841ec4b20db1a4cfe8bac81c931462",
-      "from": "git://github.com/jaredhanson/passport-ssl-certificate.git#826c16d040841ec4b20db1a4cfe8bac81c931462",
+      "version": "https://github.com/jaredhanson/passport-ssl-certificate.git#826c16d040841ec4b20db1a4cfe8bac81c931462",
+      "from": "https://github.com/jaredhanson/passport-ssl-certificate.git#826c16d040841ec4b20db1a4cfe8bac81c931462",
       "requires": {
         "passport-strategy": "1.x.x"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-ldap-connector",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "description": "ADLDAP Federation Connector",
   "main": "server.js",
   "scripts": {
@@ -51,7 +51,7 @@
     "object-sizeof": "^1.4.0",
     "passport": "~0.1.16",
     "passport-local": "~0.1.6",
-    "passport-ssl-certificate": "git://github.com/jaredhanson/passport-ssl-certificate.git#826c16d040841ec4b20db1a4cfe8bac81c931462",
+    "passport-ssl-certificate": "https://github.com/jaredhanson/passport-ssl-certificate.git#826c16d040841ec4b20db1a4cfe8bac81c931462",
     "passport-windowsauth": "^3.0.0",
     "request": "^2.88.0",
     "rimraf": "~2.5.2",


### PR DESCRIPTION
Github has deprecated unencrypted `git` protocol access. Refs using it have been updated.