### PR TITLE
Add support for LDAP user attributes selection.

### DIFF
--- a/lib/initConf.js
+++ b/lib/initConf.js
@@ -9,6 +9,7 @@ var defaults = {
   LDAP_SEARCH_LIST_GROUPS_QUERY:        '(objectCategory=group)',
   LDAP_SEARCH_GROUPS:                   '(member:1.2.840.113556.1.4.1941:={0})',
   LDAP_USER_BY_NAME:                    '(sAMAccountName={0})',
+  LDAP_USER_BY_NAME_ATTRS:              null,
   LDAP_NUMBER_OF_PARALLEL_BINDS:        1,
   LDAP_HEARTBEAT_SEARCH_QUERY:          '(&(objectclass=user)(|(sAMAccountName=foo)(UserPrincipalName=foo)))',
   WSFED_ISSUER:                         'urn:auth0',

--- a/lib/users.js
+++ b/lib/users.js
@@ -321,7 +321,11 @@ Users.prototype.getByUserName = function (userName, options, callback) {
   const filter = parseLdapFilter(nconf.get('LDAP_USER_BY_NAME').replace(/\{0\}/g, searchUsername));
   if (!filter.isValid) return callback(null);  // Input username does not resolve to valid ldap filter, return no match
 
-  var opts = { scope: 'sub', filter: filter.filter };
+  var opts = {
+    scope: 'sub',
+    filter: filter.filter,
+    attributes: nconf.get('LDAP_USER_BY_NAME_ATTRS')
+  };
   var entries = [];
 
   var done = cb(function (err) {

--- a/test/resources/mock_ldap_data.json
+++ b/test/resources/mock_ldap_data.json
@@ -44,7 +44,8 @@
     "sn": "doe",
     "uid": "jdoe",
     "uidNumber": "1000",
-    "userPassword": "123"
+    "userPassword": "123",
+    "magicPassword": "hello77"
   },
   "cn=mdoe,ou=users,dc=example,dc=org": {
     "cn": "mdoe",

--- a/test/users.unit.tests.js
+++ b/test/users.unit.tests.js
@@ -43,6 +43,7 @@ describe("users", function () {
           expect(err).to.be.null;
           expect(user.cn).to.equal("jdoe");
           expect(user.mail).to.equal("jdoe@example.org");
+          expect(user.magicPassword).to.equal("hello77");
           done();
         });
       });
@@ -56,6 +57,35 @@ describe("users", function () {
           done();
         });
       });
+
+      it("should return requested attribute only for existing user", function (done) {
+        nconf.set("LDAP_USER_BY_NAME_ATTRS", ['magicPassword']);
+        const users = new Users();
+
+        users.getByUserName("jdoe", {}, function (err, user) {
+          nconf.set("LDAP_USER_BY_NAME_ATTRS", null); // reset.
+          expect(err).to.be.null;
+          expect(user.cn).to.be.undefined;
+          expect(user.mail).to.be.undefined;
+          expect(user.magicPassword).to.equal("hello77");
+          done();
+        });
+      });
+
+      it("should return requested default and specific attributes for existing user", function (done) {
+        nconf.set("LDAP_USER_BY_NAME_ATTRS", ['*', 'magicPassword']);
+        const users = new Users();
+
+        users.getByUserName("jdoe", {}, function (err, user) {
+          nconf.set("LDAP_USER_BY_NAME_ATTRS", null); // reset.
+          expect(err).to.be.null;
+          expect(user.cn).to.equal("jdoe");
+          expect(user.mail).to.equal("jdoe@example.org");
+          expect(user.magicPassword).to.equal("hello77");
+          done();
+        });
+      });
+
     });
 
     describe("when username is not valid", function () {
@@ -73,6 +103,7 @@ describe("users", function () {
         );
       });
     });
+
   });
 
   describe("validate", function () {


### PR DESCRIPTION
Via new configuration option: `LDAP_USER_BY_NAME_ATTRS`, a list to pass
through to the underlying LDAPjs library as the `attributes` option
for `Users.getByUserName`.

Current behaviour is maintained, select the default set of attributes,
which equates to the list:

[ "*" ]

To include extra/extended attributes in addition to the defaults,
specify each one in addition to the asterisk member:

[ "*", "att1", "att2" ]

To include ALL attributes, defaults and extended, we can use the plus
sign:

[ "*", "+" ]

To select only specific attribute(s), specify each in the list, without
the asterisk member:

[ "att1", "att2" ]

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
