### PR TITLE
Fixed failure when LDAP does not supply profile.memberOf and/or groups are queried separately.

### DIFF
--- a/lib/profileMapper.js
+++ b/lib/profileMapper.js
@@ -8,7 +8,7 @@ module.exports = function (raw_data) {
     },
     nickname: raw_data['sAMAccountName'] || raw_data['cn'] || raw_data['commonName'],
     groups: raw_data['groups'],
-    emails: (raw_data.mail ? [{value: raw_data.mail }] : undefined)
+    emails: (raw_data.mail ? (Array.isArray(raw_data.mail) ? raw_data.mail : [{value: raw_data.mail}]) : undefined)
   };
 
   profile['dn'] = raw_data['dn'];

--- a/lib/users.js
+++ b/lib/users.js
@@ -533,17 +533,19 @@ Users.prototype._getAllGroupsADCached = function (profile, callback) {
     });
   }
 
-  const fromCache = memberOf.map(dn => this._groupsCache.get(dn));
+  if (memberOf) {
+    const fromCache = memberOf.map(dn => this._groupsCache.get(dn));
 
-  const resolveFromCache = fromCache.every(Boolean);
+    const resolveFromCache = fromCache.every(Boolean);
 
-  if (resolveFromCache) {
-    var result = fromCache.map((group) => {
-      return [group].concat(group.memberOf);
-    }).reduce((prev, curr) => {
-      return prev.concat(curr);
-    }, []);
-    return callback(null, uniq(result));
+    if (resolveFromCache) {
+        var result = fromCache.map((group) => {
+        return [group].concat(group.memberOf);
+        }).reduce((prev, curr) => {
+        return prev.concat(curr);
+        }, []);
+        return callback(null, uniq(result));
+    }
   }
 
   return this._getAllGroupsAD(profile.dn, (err, groups) => {


### PR DESCRIPTION
### Description

The connector crashes in users.js if profile.memberOf is undefined. And, if the groups provided are already in an array, it inappropriately nests that array in the "mail" array in profileMapper.js. The work was done in the branch "fixgroups" in my fork, I left it there for review and merging on the master side.

These two problems were discovered when during a CIC Auth0 class delivery for Okta training where for a demonstration I was trying to link to an Okta LDAP Interface which does not return "memberOf" with the user information and requires the group membership to be queried separately.

### Testing

Test with an LDAP server that does not return "memberOf". This was discovered using the connector against the Okta LDAP interface, which does not return the groups with the user. Test the groups against an LDAP server where the group membership has to be queried separately, like the Okta LDAP interface.

Unit/integration tests for these two cases do not appear to be present in the test suite, but I did not create them. I will leave the missing tests to the maintainers.

### Checklist

- [ N/A] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ N/A] All active GitHub checks for tests, formatting, and security are passing
- [ X] The correct base branch is being used, if not the default branch
