### PR TITLE
fix: update wsfed to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "win-ca": "^3.0.4",
         "winston": "~2.2.0",
         "ws": "^1.1.5",
-        "wsfed": "^7.0.0",
+        "wsfed": "^7.0.1",
         "xtend": "~2.1.1"
       },
       "devDependencies": {
@@ -375,9 +375,10 @@
       "dev": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.11.tgz",
-      "integrity": "sha512-UDi3g6Jss/W5FnSzO9jCtQwEpfymt0M+sPPlmLhDH6h2TJ8j4ESE/LpmNPBij15J5NKkk4/cg/qoVMdWI3vnlQ==",
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4427,32 +4428,27 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/saml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/saml/-/saml-1.0.1.tgz",
-      "integrity": "sha512-BzzlTdXNICrIGhJkq168n0WJpwXYr3xyMd7UHC7/s8F4M6zHSEItwEuKGmm6HjsttZk/hJcrw7fY0OZ9wE+v7Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/saml/-/saml-3.0.1.tgz",
+      "integrity": "sha512-bOjVqZcHY8PkdTBD7Y27KHykC7403BEM46SeCq5r0QPNEPE7M7RmWKy7hPjYsID9VNkCNSHYSVrrRS8Y9hNVWA==",
       "dependencies": {
         "@xmldom/xmldom": "^0.7.4",
-        "async": "~0.2.9",
-        "moment": "2.19.3",
+        "async": "^3.2.4",
+        "moment": "^2.29.4",
         "valid-url": "~1.0.9",
         "xml-crypto": "^2.1.3",
-        "xml-encryption": "^1.2.1",
+        "xml-encryption": "^2.0.0",
         "xml-name-validator": "~2.0.1",
         "xpath": "0.0.5"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/saml/node_modules/async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
-    },
-    "node_modules/saml/node_modules/moment": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
-      "integrity": "sha512-SiZ1HUDMfBpfCzL1Hm1vxUFkYDbHx8/RiWBLF+5qoVWTlBGtR15+wVQB7eSD/0w3ueDxzojlX9LQtiKVpLMsFQ==",
-      "engines": {
-        "node": "*"
-      }
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/secure-keys": {
       "version": "1.0.0",
@@ -5288,23 +5284,15 @@
       }
     },
     "node_modules/wsfed": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wsfed/-/wsfed-7.0.0.tgz",
-      "integrity": "sha512-6MTBasGr/8+EydbMAY/0oIU65K7xt4uemxSRFVJRS1HvL4WCbWqP+wNPjfOChyDG9qVadDE8OKvVLjauzvpvig==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/wsfed/-/wsfed-7.0.1.tgz",
+      "integrity": "sha512-5coEr136L7LkY9nNr97+0isFL/1+3JZnwKrPc8F7VMFgncHcmrHOXoS2hSF1nGxfJvPeDWhuXWqZUL38Dhuspw==",
       "dependencies": {
         "@auth0/thumbprint": "0.0.6",
-        "ejs": "2.5.5",
+        "ejs": "^3.1.10",
         "jsonwebtoken": "^9.0.0",
-        "saml": "^1.0.0",
+        "saml": "^3.0.1",
         "xtend": "~2.0.3"
-      }
-    },
-    "node_modules/wsfed/node_modules/ejs": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.5.tgz",
-      "integrity": "sha512-SVMZ8TKYCxHL6gb7f9QVpvnMPxZpdrT65IH6awbFex+bVAWtEYW0LoRbiViOJn6t1v/J0tVrl9fx6XOuJ5fjTA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wsfed/node_modules/is-object": {
@@ -5336,9 +5324,9 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.5.tgz",
-      "integrity": "sha512-xOSJmGFm+BTXmaPYk8pPV3duKo6hJuZ5niN4uMzoNcTlwYs0jAu/N3qY+ud9MhE4N7eMRuC1ayC7Yhmb7MmAWg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.6.tgz",
+      "integrity": "sha512-jjvpO8vHNV8QFhW5bMypP+k4BjBqHe/HrpIwpPcdUnUTIJakSIuN96o3Sdah4tKu2z64kM/JHEH8iEHGCc6Gyw==",
       "dependencies": {
         "@xmldom/xmldom": "^0.7.9",
         "xpath": "0.0.32"
@@ -5356,17 +5344,16 @@
       }
     },
     "node_modules/xml-encryption": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.3.0.tgz",
-      "integrity": "sha512-3P8C4egMMxSR1BmsRM+fG16a3WzOuUEQKS2U4c3AZ5v7OseIfdUeVkD8dwxIhuLryFZSRWUL5OP6oqkgU7hguA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-2.0.0.tgz",
+      "integrity": "sha512-4Av83DdvAgUQQMfi/w8G01aJshbEZP9ewjmZMpS9t3H+OCZBDvyK4GJPnHGfWiXlArnPbYvR58JB9qF2x9Ds+Q==",
       "dependencies": {
         "@xmldom/xmldom": "^0.7.0",
         "escape-html": "^1.0.3",
-        "node-forge": "^0.10.0",
         "xpath": "0.0.32"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
     "node_modules/xml-encryption/node_modules/xpath": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "win-ca": "^3.0.4",
     "winston": "~2.2.0",
     "ws": "^1.1.5",
-    "wsfed": "^7.0.0",
+    "wsfed": "^7.0.1",
     "xtend": "~2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Updating wsfed to latest to pull in SEC updates for `ejs`.

### References


### Testing
Tested in vivaldi. This is a patch update for wsfed. 

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
