### PR TITLE
feat: update kerberos-server version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "express-session": "^1.15.6",
         "freeport": "~1.0.2",
         "jsonwebtoken": "^9.0.2",
-        "kerberos-server": "^1.0.0",
+        "kerberos-server": "^1.1.0",
         "ldapjs": "^2.3.2",
         "lodash": "^4.17.21",
         "lru-cache": "~2.7.3",
@@ -311,6 +311,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
       "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.1",
@@ -911,6 +912,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2709,6 +2711,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
       "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -4665,9 +4668,10 @@
       }
     },
     "node_modules/kerberos-server": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/kerberos-server/-/kerberos-server-1.0.0.tgz",
-      "integrity": "sha512-rOqB8SjQPC5jKXmL1mh7RAet2WuBYuvmXXyuBE8Y42oe0AgM5BX5T0JpHhXxJAmtokkB9syKrPvVt/JBcRv7qQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/kerberos-server/-/kerberos-server-1.1.0.tgz",
+      "integrity": "sha512-LlkTCOSI4UBKfUxqqghrkTMrTrT53oEeBa0tPWnAodFAof6oDpeo4fTSgJwsOqxu8NRbn8QIHWG9o8iGxq79sA==",
+      "license": "MIT",
       "dependencies": {
         "freeport": "~1.0.2"
       }
@@ -5001,6 +5005,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8129,6 +8134,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9431,6 +9437,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.7.tgz",
       "integrity": "sha512-g7RssbTAbir1k/S7uSwSVZFfFXwpomUB9Oas0+xi9KStSCmeDXcA7rNhiskjLqvUe/Evhx8fVCT16OSa34eM5g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express-session": "^1.15.6",
     "freeport": "~1.0.2",
     "jsonwebtoken": "^9.0.2",
-    "kerberos-server": "^1.0.0",
+    "kerberos-server": "^1.1.0",
     "ldapjs": "^2.3.2",
     "lodash": "^4.17.21",
     "lru-cache": "~2.7.3",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

<!--
> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.
-->

This updates the `kerberos-server` package version from `1.0.0` to `1.1.0` to get the changes from https://github.com/auth0/node-kerberos-server/pull/4 which introduce a `maxHeaderSize` option, which defaults to `16834`.

<!--
### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
-->