### PR TITLE
fix: use tls for nssm in prepare.ps1

### DIFF
--- a/installer/prepare.ps1
+++ b/installer/prepare.ps1
@@ -1,7 +1,7 @@
 $zipDependencies = @(
     @{
         'Name'='nssm';
-        'Url'="http://nssm.cc/release/nssm-2.24.zip";
+        'Url'="https://nssm.cc/release/nssm-2.24.zip";
         'Path'= "C:\Program Files (x86)\"
         'Test'=@{
           'Path'='C:\Program Files (x86)\nssm-2.24\win32\nssm.exe'


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

- using https to download nssm instead of http


### References

- https://nssm.cc/

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality
> change CI configuration

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
