### PR TITLE
fix(security): run npm ci with --ignore-scripts

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: .nvmrc
       - name: Application Dependencies
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm i -g rimraf
       - name: Semantic Release
         id: semantic_release


### PR DESCRIPTION
This would avoid malicious scripts in vulnerable packages to be executed on CI