### PR TITLE
feat: add browser-based login test UI to mock-ldap-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ node_modules/*
 cache.db/
 .DS_store*
 .vscode
+.env
+mock-ldap-server.env

--- a/mock-ldap-server.js
+++ b/mock-ldap-server.js
@@ -1,8 +1,12 @@
 const ldap = require('ldapjs');
 const db = require('./test/resources/mock_ldap_data.json');
 const nconf = require('nconf');
+const express = require('express');
+const bodyParser = require('body-parser');
+const axios = require('axios');
 const BASE_DN = 'dc=example,dc=org';
 const LDAP_SERVER_PORT = 4444;
+const WEB_PORT = 3000;
 
 nconf.set('LDAP_URL', `ldap://0.0.0.0:${LDAP_SERVER_PORT}`);
 nconf.set('LDAP_BASE', 'dc=example,dc=org');
@@ -90,4 +94,199 @@ server.search(BASE_DN, function (req, res, next) {
 
 server.listen(LDAP_SERVER_PORT, () => {
   console.log(`LDAP server running on ${LDAP_SERVER_PORT}`);
+});
+
+// ── Web UI ────────────────────────────────────────────────────────────────────
+// A simple login form so you can simulate LDAP binds directly from the browser.
+// Test accounts (from mock_ldap_data.json):
+//   jdoe / 123   mdoe / 123   admin / admin (uses full DN)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN || '';
+const AUTH0_TENANT_HOST = process.env.AUTH0_TENANT_HOST || '';
+const AD_CONNECTION = process.env.AUTH0_CONNECTION || '';
+const AUTH0_GRANT_TYPE = process.env.AUTH0_GRANT_TYPE || '';
+const DEFAULT_CLIENT_ID = process.env.AUTH0_CLIENT_ID || '';
+const DEFAULT_CLIENT_SECRET = process.env.AUTH0_CLIENT_SECRET || '';
+
+const LOGIN_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Mock LDAP Login</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #f0f2f5; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+    .card { background: #fff; border-radius: 8px; box-shadow: 0 2px 12px rgba(0,0,0,.12); padding: 2rem; width: 420px; }
+    h1 { font-size: 1.25rem; color: #111; }
+    .tabs { display: flex; gap: .5rem; margin: 1.25rem 0 1rem; }
+    .tab { flex: 1; padding: .5rem; border: 1px solid #d1d5db; border-radius: 6px; background: #f9fafb; font-size: .85rem; cursor: pointer; text-align: center; }
+    .tab.active { background: #6366f1; color: #fff; border-color: #6366f1; }
+    .panel { display: none; }
+    .panel.active { display: block; }
+    label { display: block; font-size: .85rem; color: #555; margin-bottom: .25rem; margin-top: 1rem; }
+    input { width: 100%; padding: .6rem .75rem; border: 1px solid #d1d5db; border-radius: 6px; font-size: 1rem; }
+    input:focus { outline: none; border-color: #6366f1; box-shadow: 0 0 0 3px rgba(99,102,241,.15); }
+    button[type=submit] { margin-top: 1.5rem; width: 100%; padding: .7rem; background: #6366f1; color: #fff; border: none; border-radius: 6px; font-size: 1rem; cursor: pointer; }
+    button[type=submit]:hover { background: #4f46e5; }
+    .hint { margin-top: 1rem; font-size: .78rem; color: #888; }
+    .hint code { background: #f3f4f6; padding: 1px 4px; border-radius: 3px; }
+    .alert { margin-top: 1rem; padding: .75rem 1rem; border-radius: 6px; font-size: .9rem; }
+    .alert.success { background: #d1fae5; color: #065f46; }
+    .alert.error   { background: #fee2e2; color: #991b1b; }
+    .badge { display: inline-block; font-size: .7rem; padding: 1px 6px; border-radius: 4px; margin-left: .4rem; vertical-align: middle; }
+    .badge.ldap { background: #e0e7ff; color: #3730a3; }
+    .badge.auth0 { background: #fef3c7; color: #92400e; }
+    pre { margin-top: .5rem; font-size: .78rem; white-space: pre-wrap; word-break: break-all; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Login Test Panel</h1>
+    <div class="tabs">
+      <div class="tab active" onclick="switchTab('ldap',this)">Direct LDAP <span class="badge ldap">debug</span></div>
+      <div class="tab" onclick="switchTab('auth0',this)">Full Flow via Auth0 <span class="badge auth0">e2e</span></div>
+    </div>
+
+    <div id="panel-ldap" class="panel active">
+      <form method="POST" action="/login">
+        <label for="u1">Username (uid)</label>
+        <input id="u1" name="username" type="text" placeholder="jdoe" autocomplete="off" required>
+        <label for="p1">Password</label>
+        <input id="p1" name="password" type="password" placeholder="••••" required>
+        <button type="submit">Bind directly to LDAP :4444</button>
+      </form>
+      <p class="hint">Bypasses the connector — tests LDAP only. Accounts: <code>jdoe / 123</code> &nbsp; <code>mdoe / 123</code></p>
+    </div>
+
+    <div id="panel-auth0" class="panel">
+      <form method="POST" action="/login-auth0">
+        ${DEFAULT_CLIENT_ID ? `<input name="client_id" type="hidden" value="${DEFAULT_CLIENT_ID}">` : `<label for="cid">Client ID</label><input id="cid" name="client_id" type="text" placeholder="your client_id" autocomplete="off" required>`}
+        ${DEFAULT_CLIENT_SECRET ? `<input name="client_secret" type="hidden" value="${DEFAULT_CLIENT_SECRET}">` : `<label for="csec">Client Secret</label><input id="csec" name="client_secret" type="password" placeholder="your client secret" autocomplete="off" required>`}
+        <label for="u2">Username (uid)</label>
+        <input id="u2" name="username" type="text" placeholder="jdoe" autocomplete="off" required>
+        <label for="p2">Password</label>
+        <input id="p2" name="password" type="password" placeholder="••••" required>
+        <button type="submit">Login via Auth0 → Connector → LDAP</button>
+      </form>
+      <p class="hint">Full e2e login flow through the connector.</p>
+    </div>
+
+    {{RESULT}}
+  </div>
+  <script>
+    function switchTab(name, el) {
+      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+      el.classList.add('active');
+      document.getElementById('panel-' + name).classList.add('active');
+    }
+    // Keep active tab after form submit
+    const hash = location.hash;
+    if (hash === '#auth0') switchTab('auth0', document.querySelectorAll('.tab')[1]);
+  </script>
+</body>
+</html>`;
+
+const app = express();
+app.use(bodyParser.urlencoded({ extended: false }));
+
+app.get('/', (req, res) => {
+  res.send(LOGIN_HTML.replace('{{RESULT}}', ''));
+});
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const userDN = `cn=${username},ou=users,${BASE_DN}`;
+
+  const client = ldap.createClient({ url: `ldap://127.0.0.1:${LDAP_SERVER_PORT}` });
+
+  client.on('error', (err) => {
+    const html = `<div class="alert error">Connection error: ${err.message}</div>`;
+    res.send(LOGIN_HTML.replace('{{RESULT}}', html));
+  });
+
+  client.bind(userDN, password, (bindErr) => {
+    if (bindErr) {
+      client.destroy();
+      const html = `<div class="alert error"><strong>Login failed</strong> — ${bindErr.message}</div>`;
+      return res.send(LOGIN_HTML.replace('{{RESULT}}', html));
+    }
+
+    // Bind succeeded — search for the user's full attributes
+    client.search(BASE_DN, {
+      scope: 'sub',
+      filter: `(uid=${username})`,
+      attributes: ['cn', 'uid', 'mail', 'givenName', 'sn', 'objectClass']
+    }, (searchErr, searchRes) => {
+      const entries = [];
+
+      searchRes.on('searchEntry', (entry) => entries.push(entry.object));
+
+      searchRes.on('end', () => {
+        client.destroy();
+        const user = entries[0] || { dn: userDN };
+        const html = `
+          <div class="alert success">
+            <strong>Login successful</strong>
+            <pre>${JSON.stringify(user, null, 2)}</pre>
+          </div>`;
+        res.send(LOGIN_HTML.replace('{{RESULT}}', html));
+      });
+
+      if (searchErr) {
+        client.destroy();
+        const html = `<div class="alert success"><strong>Login successful</strong> (could not fetch user details)</div>`;
+        res.send(LOGIN_HTML.replace('{{RESULT}}', html));
+      }
+    });
+  });
+});
+
+app.post('/login-auth0', async (req, res) => {
+  const { client_id, client_secret, username, password } = req.body;
+
+  try {
+    const params = new URLSearchParams({
+      grant_type: AUTH0_GRANT_TYPE,
+      client_id,
+      client_secret,
+      username,
+      password,
+      realm: AD_CONNECTION,
+      scope: 'openid profile email',
+    });
+
+    const response = await axios.post(`${AUTH0_DOMAIN}/oauth/token`, params, {
+      headers: {
+        Host: AUTH0_TENANT_HOST,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+
+    const { access_token, id_token } = response.data;
+
+    // Decode id_token payload (no verification needed — this is local dev)
+    const payload = JSON.parse(Buffer.from(id_token.split('.')[1], 'base64url').toString());
+
+    const html = `
+      <div class="alert success">
+        <strong>Login successful — identity saved in auth0-server</strong>
+        <pre>${JSON.stringify(payload, null, 2)}</pre>
+        <details style="margin-top:.5rem">
+          <summary style="cursor:pointer;font-size:.8rem">access_token</summary>
+          <pre style="font-size:.7rem">${access_token}</pre>
+        </details>
+      </div>`;
+    res.send(LOGIN_HTML.replace('{{RESULT}}', html) + '<script>location.hash="auth0"</script>');
+
+  } catch (err) {
+    const detail = err.response ? JSON.stringify(err.response.data, null, 2) : err.message;
+    const html = `<div class="alert error"><strong>Login failed</strong><pre>${detail}</pre></div>`;
+    res.send(LOGIN_HTML.replace('{{RESULT}}', html) + '<script>location.hash="auth0"</script>');
+  }
+});
+
+app.listen(WEB_PORT, () => {
+  console.log(`Login UI running at http://localhost:${WEB_PORT}`);
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "NODE_TLS_REJECT_UNAUTHORIZED=0 mocha --timeout 50000 --reporter spec --exit",
     "snyk": "snyk test",
     "start": "node server.js",
-    "start-local": "source .env && npm run start"
+    "start-local": "source .env && node server.js",
+    "start-mock": "node --env-file=mock-ldap-server.env mock-ldap-server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Adds a browser-accessible login test panel to `mock-ldap-server.js` on port 3000
- **Direct LDAP tab**: binds directly to the mock LDAP server for debugging — bypasses the connector entirely
- **Full Flow tab**: triggers a full e2e login through the connector
- All environment-specific configuration loaded from `mock-ldap-server.env` (gitignored) — client credentials are hidden from the UI when pre-configured
- Adds `npm run start-mock` script to `package.json`
- Adds `.env` and `mock-ldap-server.env` to `.gitignore`

## Test plan

- [ ] Copy `mock-ldap-server.env` and fill in your values
- [ ] Run `npm run start-mock`
- [ ] Open `http://localhost:3000`
- [ ] Direct LDAP tab: login with test credentials — should show user attributes
- [ ] Full Flow tab: login with valid credentials — should show decoded identity payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)