### PR TITLE
feat: re-fetch signing keys on reconnect + support JWKS

### DIFF
--- a/endpoints.js
+++ b/endpoints.js
@@ -1,7 +1,7 @@
 const passport = require('passport');
 const config = require('./lib/config');
-const jwt = require('jsonwebtoken');
 const logout = require('express-passport-logout');
+const signingKeys = require('./lib/signingKeys');
 
 const wsfederationResponses = require('./lib/wsfederation-responses');
 const Users = require('./lib/users');
@@ -18,7 +18,9 @@ exports.install = async function (app) {
     }
 
     var token = req.headers.authorization.replace('Bearer ', '');
-    jwt.verify(token, config.get('TENANT_SIGNING_KEY'), function (err) {
+    // Resolved through signingKeys so this keeps working when the tenant signing key is served
+    // from the JWKS endpoint rather than stored in TENANT_SIGNING_KEY.
+    signingKeys.verify(token, function (err) {
       if (err) {
         console.log('Validate Access Token Error', err);
         return res.send(401);

--- a/lib/configureConnection.js
+++ b/lib/configureConnection.js
@@ -32,13 +32,30 @@ async function configureConnection({ provisioningTicket, connectionName }) {
       signInEndpoint: signInEndpoint,
       agentMode: config.get('AGENT_MODE'),
       agentVersion: require('../package').version,
+      capabilities: {
+        // Reported unconditionally: the connector cannot inspect the tenant's deprecation status,
+        // and this is simply a guarantee that it is able to retrieve the tenant signing key from
+        // the JWKS endpoint itself. Whether the server acts on it is the server's decision.
+        useJWKS: true
+      }
     });
+
+    // An empty tenantSigningKey means the server accepted the useJWKS capability and expects this
+    // connector to resolve the signing key from the JWKS endpoint itself. A non-empty value means
+    // the tenant is still on the deprecated behaviour (or the server predates `capabilities`), and
+    // that key is what hub messages must be verified with.
+    const tenantSigningKey = response.data.signingKey || '';
+    console.log(
+      tenantSigningKey
+        ? ' > Received a tenant signing key from Auth0.'
+        : ' > No signing key received; tenant signing keys will be read from the JWKS endpoint.'
+    );
     console.log(('Connection ' + connectionName + ' configured.').green);
 
     return {
       serverUrl,
       certThumbprint,
-      tenantSigningKey: response.data.signingKey || ''
+      tenantSigningKey
     };
   } catch (err) {
     if (err.response && err.response.status !== 200) {

--- a/lib/signingKeys.js
+++ b/lib/signingKeys.js
@@ -1,0 +1,404 @@
+const crypto = require('crypto');
+const axios = require('axios');
+const jwt = require('jsonwebtoken');
+
+const config = require('./config');
+const { configureConnection } = require('./configureConnection');
+
+/**
+ * Relative path of the tenant JWKS document.
+ *
+ * The tenant segment of the route is optional and ignored by the server
+ * (`/:tenant_ignore?/.well-known/jwks.json`), so the document is resolved against the origin of
+ * the provisioning ticket.
+ */
+const JWKS_PATH = '/.well-known/jwks.json';
+
+/**
+ * How long a successfully fetched JWKS document is considered fresh.
+ */
+const DEFAULT_CACHE_MAX_AGE_MS = 10 * 60 * 1000;
+
+/**
+ * Lower bound between two fetch attempts. Reconnects are driven by WS_RECONNECT_INTERVAL_MS
+ * (10 seconds by default), so without a floor a reconnect loop would hammer the tenant.
+ */
+const DEFAULT_MIN_REFRESH_INTERVAL_MS = 30 * 1000;
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 1000;
+
+/**
+ * Asymmetric algorithms we are willing to verify hub messages with when the key came from a JWKS
+ * document. `none` and the HMAC family are deliberately excluded: JWKS keys are public, so
+ * accepting an HMAC algorithm would let a published public key be used as a shared secret.
+ */
+const JWKS_ALGORITHMS = [
+  'RS256', 'RS384', 'RS512',
+  'PS256', 'PS384', 'PS512',
+  'ES256', 'ES384', 'ES512'
+];
+
+const SUPPORTED_KEY_TYPES = ['RSA', 'EC'];
+
+/**
+ * Resolves the signing key used to verify messages coming from the hub.
+ *
+ * There are two modes, decided by what `auth0-server` returned during the provisioning ticket
+ * process (see `lib/configureConnection.js`):
+ *
+ *  - JWKS mode - the server did not return a `signingKey`, because this connector advertised the
+ *    `useJWKS` capability and the tenant is no longer on the deprecated behaviour. The key is
+ *    read from the tenant JWKS document and selected by `kid`.
+ *  - Static mode - the server returned a `signingKey` (a global client key or a tenant signing
+ *    key), so the tenant is still on some variation of the deprecated behaviour. The key is read
+ *    from `TENANT_SIGNING_KEY`, exactly as it was before this module existed. This is the path an
+ *    older `auth0-server` that ignores `capabilities` will always take.
+ */
+class SigningKeys {
+  #config;
+  #axios;
+  #jwt;
+  #configureConnectionFn;
+  #cacheMaxAgeMs;
+  #minRefreshIntervalMs;
+  #requestTimeoutMs;
+
+  // kid -> PEM encoded public key. Empty until the first successful fetch.
+  #keys;
+  // Timestamp of the last *successful* fetch, used for freshness.
+  #fetchedAt;
+  // Timestamp of the last fetch *attempt*, used for the cooldown.
+  #lastAttemptAt;
+  // Shared promise so concurrent verifications trigger a single fetch.
+  #inFlight;
+
+  /**
+   * @param configModule config module
+   * @param axiosModule axios module
+   * @param jwtModule jsonwebtoken module
+   * @param configureConnectionFn override for the provisioning ticket function (used by tests);
+   *   defaults to the shared `lib/configureConnection` implementation.
+   * @param cacheMaxAgeMs how long a fetched JWKS document stays fresh
+   * @param minRefreshIntervalMs minimum delay between two fetch attempts
+   * @param requestTimeoutMs timeout applied to the JWKS request
+   */
+  constructor({
+    configModule = config,
+    axiosModule = axios,
+    jwtModule = jwt,
+    configureConnectionFn = null,
+    cacheMaxAgeMs = DEFAULT_CACHE_MAX_AGE_MS,
+    minRefreshIntervalMs = DEFAULT_MIN_REFRESH_INTERVAL_MS,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+  } = {}) {
+    this.#config = configModule;
+    this.#axios = axiosModule;
+    this.#jwt = jwtModule;
+    this.#configureConnectionFn = configureConnectionFn;
+    this.#cacheMaxAgeMs = cacheMaxAgeMs;
+    this.#minRefreshIntervalMs = minRefreshIntervalMs;
+    this.#requestTimeoutMs = requestTimeoutMs;
+
+    this.#keys = {};
+    this.#fetchedAt = 0;
+    this.#lastAttemptAt = 0;
+    this.#inFlight = null;
+  }
+
+  /**
+   * True when this connector is responsible for fetching the signing key itself.
+   *
+   * The provisioning ticket process stores `response.data.signingKey || ''`, so an absent or empty
+   * `TENANT_SIGNING_KEY` means the server chose not to send one down.
+   *
+   * @return {boolean}
+   */
+  useJwks() {
+    const staticKey = this.#config.get('TENANT_SIGNING_KEY');
+    return !staticKey || staticKey.trim() === '';
+  }
+
+  /**
+   * Absolute URL of the tenant JWKS document, derived from the provisioning ticket origin.
+   *
+   * @return {string}
+   */
+  jwksUri() {
+    const provisioningTicket = this.#config.get('PROVISIONING_TICKET');
+    if (!provisioningTicket) {
+      throw new Error('Cannot resolve the JWKS endpoint because PROVISIONING_TICKET is not set.');
+    }
+
+    const ticketUrl = new URL(provisioningTicket);
+    if (ticketUrl.protocol !== 'https:') {
+      console.warn(
+        ('The provisioning ticket is not using https, so the JWKS document will be fetched over ' +
+          ticketUrl.protocol.replace(':', '') + '.').yellow
+      );
+    }
+
+    return new URL(JWKS_PATH, ticketUrl.origin).toString();
+  }
+
+  /**
+   * Verifies a token received from the hub, resolving the signing key according to the current
+   * mode. Signature is intentionally the same shape as `jwt.verify`.
+   *
+   * @param {string} token
+   * @param {function} callback called with (err, payload)
+   */
+  verify(token, callback) {
+    if (!this.useJwks()) {
+      // Deprecated behaviour, unchanged: verify against the key the server sent us. No algorithm
+      // allow list is applied here so that existing deployments keep verifying exactly as before.
+      return this.#jwt.verify(token, this.#config.get('TENANT_SIGNING_KEY'), callback);
+    }
+
+    this.#jwt.verify(
+      token,
+      (header, done) => this.#resolveKey(header, done),
+      { algorithms: JWKS_ALGORITHMS },
+      callback
+    );
+  }
+
+  /**
+   * Key resolver handed to `jwt.verify`. Looks the `kid` up in the cache, fetching the JWKS
+   * document when the cache is cold, stale, or does not contain the requested key.
+   */
+  #resolveKey(header, done) {
+    const kid = header && header.kid;
+
+    const lookup = () => {
+      const key = this.#selectKey(kid);
+      if (!key) {
+        return done(new Error(
+          kid
+            ? `No signing key matching kid "${kid}" was found in ${this.#safeJwksUri()}.`
+            : `The message has no kid and ${Object.keys(this.#keys).length} signing keys are available, so the key is ambiguous.`
+        ));
+      }
+      done(null, key);
+    };
+
+    // A cache hit on a fresh document is the common case and needs no network call.
+    if (this.#isFresh() && this.#selectKey(kid)) {
+      return lookup();
+    }
+
+    // We only get here on a stale document or an unknown kid, and an unknown kid most likely means
+    // the tenant rotated its keys since the last fetch. Forcing the fetch means rotation is picked
+    // up even inside the freshness window; the cooldown still prevents hammering the tenant. If the
+    // refresh fails we still run the lookup, so the caller gets a verification error rather than a
+    // dangling callback.
+    this.refresh({ force: true })
+      .then(lookup, (err) => {
+        console.error('Could not fetch the tenant signing keys: ' + err.message);
+        lookup();
+      });
+  }
+
+  /**
+   * Picks a key by `kid`. When the message carries no `kid`, this only succeeds if the document
+   * contains exactly one key, since anything else would be a guess.
+   *
+   * @return {string|null} PEM encoded public key
+   */
+  #selectKey(kid) {
+    if (kid) {
+      return this.#keys[kid] || null;
+    }
+
+    const available = Object.keys(this.#keys);
+    return available.length === 1 ? this.#keys[available[0]] : null;
+  }
+
+  #isFresh() {
+    return this.#fetchedAt > 0 && (Date.now() - this.#fetchedAt) < this.#cacheMaxAgeMs;
+  }
+
+  #withinCooldown() {
+    return this.#lastAttemptAt > 0 && (Date.now() - this.#lastAttemptAt) < this.#minRefreshIntervalMs;
+  }
+
+  #safeJwksUri() {
+    try {
+      return this.jwksUri();
+    } catch (err) {
+      return 'the JWKS endpoint';
+    }
+  }
+
+  /**
+   * Fetches the JWKS document and replaces the cache. Concurrent callers share a single request.
+   *
+   * A failed fetch never clears a previously cached document. Continuing to verify with keys that
+   * may be outdated is safe: these are public keys, so a stale key can only make verification
+   * fail, never make an invalid signature pass.
+   *
+   * @param {boolean} force ignore the freshness window (the cooldown still applies)
+   * @return {Promise<void>}
+   */
+  refresh({ force = false } = {}) {
+    if (!force && this.#isFresh()) {
+      return Promise.resolve();
+    }
+
+    if (this.#inFlight) {
+      return this.#inFlight;
+    }
+
+    if (this.#withinCooldown()) {
+      return Promise.resolve();
+    }
+
+    this.#lastAttemptAt = Date.now();
+    this.#inFlight = this.#fetchJwks()
+      .finally(() => {
+        this.#inFlight = null;
+      });
+
+    return this.#inFlight;
+  }
+
+  async #fetchJwks() {
+    const uri = this.jwksUri();
+    console.log('Fetching tenant signing keys from ' + uri);
+
+    // The request deliberately relies on the process wide https configuration so that the
+    // HTTP_PROXY tunnel installed by lib/setupProxy and the CA bundle injected by lib/add_certs
+    // both apply, and so that Node's default minimum TLS version is honoured.
+    const response = await this.#axios.get(uri, { timeout: this.#requestTimeoutMs });
+
+    const keys = response && response.data && response.data.keys;
+    if (!Array.isArray(keys)) {
+      throw new Error(`Unexpected JWKS document at ${uri}: no "keys" array.`);
+    }
+
+    const parsed = {};
+    keys.forEach((jwk) => {
+      const pem = this.#jwkToPem(jwk);
+      if (pem) {
+        parsed[jwk.kid] = pem;
+      }
+    });
+
+    if (Object.keys(parsed).length === 0) {
+      throw new Error(`No usable signing keys found in the JWKS document at ${uri}.`);
+    }
+
+    this.#keys = parsed;
+    this.#fetchedAt = Date.now();
+    console.log('Loaded ' + Object.keys(parsed).length + ' tenant signing key(s).');
+  }
+
+  /**
+   * Converts a JWK into a PEM encoded public key, skipping anything we cannot or should not use.
+   *
+   * @return {string|null}
+   */
+  #jwkToPem(jwk) {
+    if (!jwk || !jwk.kid) {
+      console.warn('Skipping a JWKS entry without a kid.'.yellow);
+      return null;
+    }
+
+    // `use` is optional, but when present it must mark the key as a signature key.
+    if (jwk.use && jwk.use !== 'sig') {
+      return null;
+    }
+
+    if (!SUPPORTED_KEY_TYPES.includes(jwk.kty)) {
+      console.warn(`Skipping JWKS entry "${jwk.kid}" with unsupported key type "${jwk.kty}".`.yellow);
+      return null;
+    }
+
+    if (jwk.alg && !JWKS_ALGORITHMS.includes(jwk.alg)) {
+      console.warn(`Skipping JWKS entry "${jwk.kid}" with unsupported algorithm "${jwk.alg}".`.yellow);
+      return null;
+    }
+
+    try {
+      return crypto
+        .createPublicKey({ key: jwk, format: 'jwk' })
+        .export({ type: 'spki', format: 'pem' })
+        .toString();
+    } catch (err) {
+      console.warn(`Skipping unreadable JWKS entry "${jwk.kid}": ${err.message}`.yellow);
+      return null;
+    }
+  }
+
+  /**
+   * Re-fetches the tenant signing key because the connector is (re)connecting to the hub.
+   *
+   * The hub may have started signing with a different key while the socket was down, so the key
+   * captured at setup time can no longer be assumed current.
+   *
+   * Failures are logged and swallowed: the connector must still attempt to connect with whatever
+   * key it already has rather than wedge itself into a permanently broken state.
+   *
+   * @return {Promise<boolean>} true when a key was actually refreshed
+   */
+  async refreshOnReconnect() {
+    if (this.#withinCooldown()) {
+      return false;
+    }
+
+    try {
+      if (this.useJwks()) {
+        await this.refresh({ force: true });
+        return true;
+      }
+
+      await this.#refreshViaProvisioningTicket();
+      return true;
+    } catch (err) {
+      console.error('Could not refresh the tenant signing key: ' + err.message);
+      return false;
+    }
+  }
+
+  /**
+   * Runs the provisioning ticket process again to pick up the current signing key.
+   *
+   * This re-sends the `useJWKS` capability, so a tenant that stopped using the deprecated
+   * behaviour since setup will now respond without a `signingKey` and this connector will switch
+   * itself over to JWKS mode.
+   */
+  async #refreshViaProvisioningTicket() {
+    this.#lastAttemptAt = Date.now();
+
+    const provisioningTicket = this.#config.get('PROVISIONING_TICKET');
+    if (!provisioningTicket) {
+      throw new Error('PROVISIONING_TICKET is not set.');
+    }
+
+    console.log('Refreshing the tenant signing key through the provisioning ticket.');
+
+    const configureConnection = this.#configureConnection();
+    const { serverUrl, certThumbprint, tenantSigningKey } = await configureConnection({
+      provisioningTicket,
+      connectionName: this.#config.get('CONNECTION')
+    });
+
+    // configureConnection no longer writes config itself (it returns the values), so persist them
+    // here, the same way server.js does after the initial setup.
+    this.#config.set('SERVER_URL', serverUrl);
+    this.#config.set('LAST_SENT_THUMBPRINT', certThumbprint);
+    this.#config.set('TENANT_SIGNING_KEY', tenantSigningKey);
+
+    // Persist the refreshed key so a restart does not need another round trip.
+    await this.#config.save();
+  }
+
+  #configureConnection() {
+    return this.#configureConnectionFn || configureConnection;
+  }
+}
+
+const signingKeys = new SigningKeys();
+
+module.exports = signingKeys;
+module.exports.SigningKeys = SigningKeys;
+module.exports.JWKS_ALGORITHMS = JWKS_ALGORITHMS;

--- a/lib/signingKeys.js
+++ b/lib/signingKeys.js
@@ -149,9 +149,17 @@ class SigningKeys {
    */
   verify(token, callback) {
     if (!this.useJwks()) {
-      // Deprecated behaviour, unchanged: verify against the key the server sent us. No algorithm
-      // allow list is applied here so that existing deployments keep verifying exactly as before.
-      return this.#jwt.verify(token, this.#config.get('TENANT_SIGNING_KEY'), callback);
+      // Deprecated behaviour: verify against the key the server sent us. The key is always
+      // asymmetric (a global client key or a tenant signing key), so we constrain verification to
+      // the same asymmetric allow list as JWKS mode. This rejects the algorithm-confusion attack
+      // where a token forged with the (public) key as an HMAC secret would otherwise verify, since
+      // `jsonwebtoken` accepts any algorithm when none is specified.
+      return this.#jwt.verify(
+        token,
+        this.#config.get('TENANT_SIGNING_KEY'),
+        { algorithms: JWKS_ALGORITHMS },
+        callback
+      );
     }
 
     this.#jwt.verify(
@@ -376,6 +384,8 @@ class SigningKeys {
 
     console.log('Refreshing the tenant signing key through the provisioning ticket.');
 
+    const previousKey = this.#config.get('TENANT_SIGNING_KEY');
+
     const configureConnection = this.#configureConnection();
     const { serverUrl, certThumbprint, tenantSigningKey } = await configureConnection({
       provisioningTicket,
@@ -388,8 +398,11 @@ class SigningKeys {
     this.#config.set('LAST_SENT_THUMBPRINT', certThumbprint);
     this.#config.set('TENANT_SIGNING_KEY', tenantSigningKey);
 
-    // Persist the refreshed key so a restart does not need another round trip.
-    await this.#config.save();
+    // Persist only when the key actually changed. Reconnects happen on every network blip, so an
+    // unconditional save would write to disk each time even though the key is usually unchanged.
+    if (tenantSigningKey !== previousKey) {
+      await this.#config.save();
+    }
   }
 
   #configureConnection() {

--- a/test/configureConnection.tests.js
+++ b/test/configureConnection.tests.js
@@ -172,6 +172,19 @@ describe('configureConnection', function () {
 
       expect(stubs.axiosStub._calls[0].body.agentVersion).to.equal('1.2.3');
     });
+
+    it('reports the useJWKS capability regardless of the response', async function () {
+      // Reported unconditionally so auth0-server can, depending on the tenant's deprecation status,
+      // choose to stop sending a signing key down and let the connector read it from the JWKS
+      // endpoint. The connector cannot inspect deprecation status itself.
+      const withKey = makeStubs({ axiosResponse: { data: { signingKey: FAKE_SIGNING_KEY } } });
+      await loadModule(withKey).configureConnection({ provisioningTicket: PROVISIONING_TICKET, connectionName: CONNECTION_NAME });
+      expect(withKey.axiosStub._calls[0].body.capabilities).to.deep.equal({ useJWKS: true });
+
+      const withoutKey = makeStubs({ axiosResponse: { data: {} } });
+      await loadModule(withoutKey).configureConnection({ provisioningTicket: PROVISIONING_TICKET, connectionName: CONNECTION_NAME });
+      expect(withoutKey.axiosStub._calls[0].body.capabilities).to.deep.equal({ useJWKS: true });
+    });
   });
 
   describe('error handling', function () {

--- a/test/signingKeys.tests.js
+++ b/test/signingKeys.tests.js
@@ -305,6 +305,23 @@ describe('signingKeys', () => {
         done();
       });
     });
+
+    it('rejects an HS256 token forged with the static key as the secret', (done) => {
+      const key = generateKey('kid-1');
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig({ TENANT_SIGNING_KEY: key.publicPem })
+      });
+
+      // Same algorithm-confusion attack as JWKS mode: the static key is asymmetric, so an HMAC
+      // token signed with it as the secret must not verify.
+      const forged = jwt.sign({ username: 'attacker' }, key.publicPem, { algorithm: 'HS256' });
+
+      signingKeys.verify(forged, (err) => {
+        expect(err).to.be.ok;
+        expect(err.message).to.match(/invalid algorithm/i);
+        done();
+      });
+    });
   });
 
   describe('JWKS fetch failures', () => {
@@ -458,6 +475,23 @@ describe('signingKeys', () => {
       expect(config.get('TENANT_SIGNING_KEY')).to.equal('a-rotated-key');
       expect(config.saveCalls).to.equal(1);
       expect(axiosStub.requests).to.have.length(0);
+    });
+
+    it('does not persist when the re-provisioned signing key is unchanged', async () => {
+      const config = makeConfig({ TENANT_SIGNING_KEY: 'an-old-key', CONNECTION: 'my-ad' });
+      const signingKeys = new SigningKeys({
+        configModule: config,
+        axiosModule: makeAxios(() => { throw new Error('the JWKS endpoint must not be called in static key mode'); }),
+        minRefreshIntervalMs: 0,
+        // Reconnect with no rotation: the same key comes back, so there is nothing to persist.
+        configureConnectionFn: async () => ({ serverUrl: 'https://connector.example.com', certThumbprint: 'aa:bb', tenantSigningKey: 'an-old-key' })
+      });
+
+      const refreshed = await signingKeys.refreshOnReconnect();
+
+      expect(refreshed).to.equal(true);
+      expect(config.get('TENANT_SIGNING_KEY')).to.equal('an-old-key');
+      expect(config.saveCalls).to.equal(0);
     });
 
     it('switches to JWKS mode when the provisioning ticket stops returning a signing key', async () => {

--- a/test/signingKeys.tests.js
+++ b/test/signingKeys.tests.js
@@ -1,0 +1,542 @@
+require('colors');
+
+const { expect } = require('chai');
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
+
+const { SigningKeys } = require('../lib/signingKeys');
+
+const PROVISIONING_TICKET = 'https://tenant.example.com/p/ad/abc123';
+const JWKS_URI = 'https://tenant.example.com/.well-known/jwks.json';
+
+/**
+ * Generates an RSA key pair and the matching JWKS entry for a given kid.
+ */
+function generateKey(kid) {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+
+  const jwk = publicKey.export({ format: 'jwk' });
+  jwk.kid = kid;
+  jwk.use = 'sig';
+  jwk.alg = 'RS256';
+
+  return {
+    kid,
+    jwk,
+    privatePem: privateKey.export({ type: 'pkcs8', format: 'pem' }),
+    publicPem: publicKey.export({ type: 'spki', format: 'pem' }).toString()
+  };
+}
+
+function sign(key, payload = { username: 'jsmith' }) {
+  return jwt.sign(payload, key.privatePem, { algorithm: 'RS256', keyid: key.kid });
+}
+
+function makeConfig(values = {}) {
+  const store = Object.assign({ PROVISIONING_TICKET: PROVISIONING_TICKET }, values);
+
+  return {
+    values: store,
+    get: (key) => store[key],
+    set: (key, value) => {
+      store[key] = value;
+    },
+    saveCalls: 0,
+    save: async function () {
+      this.saveCalls++;
+    }
+  };
+}
+
+/**
+ * Minimal axios stub that records the URLs it was asked for.
+ */
+function makeAxios(handler) {
+  return {
+    requests: [],
+    get: function (url, options) {
+      this.requests.push({ url, options });
+      return handler(url, options);
+    }
+  };
+}
+
+function jwksResponse(keys) {
+  return Promise.resolve({ data: { keys: keys.map((k) => k.jwk) } });
+}
+
+describe('signingKeys', () => {
+
+  describe('mode detection', () => {
+    it('uses JWKS when the server did not send a signing key', () => {
+      const signingKeys = new SigningKeys({ configModule: makeConfig() });
+
+      expect(signingKeys.useJwks()).to.equal(true);
+    });
+
+    it('uses JWKS when the stored signing key is blank', () => {
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig({ TENANT_SIGNING_KEY: '   ' })
+      });
+
+      expect(signingKeys.useJwks()).to.equal(true);
+    });
+
+    it('uses the static key when the server sent a signing key', () => {
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig({ TENANT_SIGNING_KEY: 'a-global-client-key' })
+      });
+
+      expect(signingKeys.useJwks()).to.equal(false);
+    });
+  });
+
+  describe('jwksUri', () => {
+    it('derives the JWKS document from the provisioning ticket origin', () => {
+      const signingKeys = new SigningKeys({ configModule: makeConfig() });
+
+      expect(signingKeys.jwksUri()).to.equal(JWKS_URI);
+    });
+
+    it('throws when there is no provisioning ticket', () => {
+      const config = makeConfig();
+      config.set('PROVISIONING_TICKET', undefined);
+      const signingKeys = new SigningKeys({ configModule: config });
+
+      expect(() => signingKeys.jwksUri()).to.throw(/PROVISIONING_TICKET is not set/);
+    });
+  });
+
+  describe('verify in JWKS mode', () => {
+    it('verifies a token signed with a key from the JWKS document', (done) => {
+      const key = generateKey('kid-1');
+      const axiosStub = makeAxios(() => jwksResponse([key]));
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: axiosStub
+      });
+
+      signingKeys.verify(sign(key), (err, payload) => {
+        expect(err).to.equal(null);
+        expect(payload.username).to.equal('jsmith');
+        expect(axiosStub.requests[0].url).to.equal(JWKS_URI);
+        done();
+      });
+    });
+
+    it('selects the key matching the kid when several are published', (done) => {
+      const keyOne = generateKey('kid-1');
+      const keyTwo = generateKey('kid-2');
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => jwksResponse([keyOne, keyTwo]))
+      });
+
+      // Signed with the second key, so selection by kid is what makes this pass.
+      signingKeys.verify(sign(keyTwo), (err, payload) => {
+        expect(err).to.equal(null);
+        expect(payload.username).to.equal('jsmith');
+        done();
+      });
+    });
+
+    it('rejects a token whose kid is not published', (done) => {
+      const published = generateKey('kid-1');
+      const rogue = generateKey('kid-unknown');
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => jwksResponse([published]))
+      });
+
+      signingKeys.verify(sign(rogue), (err) => {
+        expect(err).to.be.ok;
+        expect(err.message).to.match(/kid "kid-unknown"/);
+        done();
+      });
+    });
+
+    it('rejects a token signed by a different key with a published kid', (done) => {
+      const published = generateKey('kid-1');
+      // Same kid, different key material - a forged token.
+      const forged = generateKey('kid-1');
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => jwksResponse([published]))
+      });
+
+      signingKeys.verify(sign(forged), (err) => {
+        expect(err).to.be.ok;
+        expect(err.message).to.match(/invalid signature/i);
+        done();
+      });
+    });
+
+    it('rejects an HS256 token forged with the published public key as the secret', (done) => {
+      const key = generateKey('kid-1');
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => jwksResponse([key]))
+      });
+
+      // Classic algorithm confusion attack: sign with HMAC using the public key as the secret.
+      const forged = jwt.sign({ username: 'attacker' }, key.publicPem, {
+        algorithm: 'HS256',
+        keyid: 'kid-1'
+      });
+
+      signingKeys.verify(forged, (err) => {
+        expect(err).to.be.ok;
+        expect(err.message).to.match(/invalid algorithm/i);
+        done();
+      });
+    });
+
+    it('falls back to the single published key when the token carries no kid', (done) => {
+      const key = generateKey('kid-1');
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => jwksResponse([key]))
+      });
+
+      const token = jwt.sign({ username: 'jsmith' }, key.privatePem, { algorithm: 'RS256' });
+
+      signingKeys.verify(token, (err, payload) => {
+        expect(err).to.equal(null);
+        expect(payload.username).to.equal('jsmith');
+        done();
+      });
+    });
+
+    it('refuses to guess when the token has no kid and several keys are published', (done) => {
+      const keyOne = generateKey('kid-1');
+      const keyTwo = generateKey('kid-2');
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => jwksResponse([keyOne, keyTwo]))
+      });
+
+      const token = jwt.sign({ username: 'jsmith' }, keyOne.privatePem, { algorithm: 'RS256' });
+
+      signingKeys.verify(token, (err) => {
+        expect(err).to.be.ok;
+        expect(err.message).to.match(/no kid/);
+        done();
+      });
+    });
+
+    it('re-fetches on an unknown kid even while the cached document is still fresh', async () => {
+      const oldKey = generateKey('kid-old');
+      const newKey = generateKey('kid-new');
+      let current = [oldKey];
+      const axiosStub = makeAxios(() => jwksResponse(current));
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: axiosStub,
+        // Long freshness window, no cooldown: rotation must still be picked up.
+        cacheMaxAgeMs: 60 * 60 * 1000,
+        minRefreshIntervalMs: 0
+      });
+
+      const first = await new Promise((resolve) => signingKeys.verify(sign(oldKey), resolve));
+      expect(first).to.equal(null);
+
+      // The tenant rotates to a new kid without the cache having expired.
+      current = [newKey];
+      const payload = await new Promise((resolve, reject) => {
+        signingKeys.verify(sign(newKey), (err, p) => err ? reject(err) : resolve(p));
+      });
+
+      expect(payload.username).to.equal('jsmith');
+      expect(axiosStub.requests).to.have.length(2);
+    });
+
+    it('caches the JWKS document across verifications', async () => {
+      const key = generateKey('kid-1');
+      const axiosStub = makeAxios(() => jwksResponse([key]));
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: axiosStub
+      });
+
+      const verifyOnce = () => new Promise((resolve) => signingKeys.verify(sign(key), resolve));
+
+      await verifyOnce();
+      await verifyOnce();
+      await verifyOnce();
+
+      expect(axiosStub.requests).to.have.length(1);
+    });
+
+    it('shares a single request between concurrent refreshes', async () => {
+      const key = generateKey('kid-1');
+      let resolveFetch;
+      const axiosStub = makeAxios(() => new Promise((resolve) => {
+        resolveFetch = () => resolve({ data: { keys: [key.jwk] } });
+      }));
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: axiosStub
+      });
+
+      const first = signingKeys.refresh();
+      const second = signingKeys.refresh();
+      resolveFetch();
+      await Promise.all([first, second]);
+
+      expect(axiosStub.requests).to.have.length(1);
+    });
+  });
+
+  describe('verify in static key mode', () => {
+    it('verifies against the key the server sent, without touching the JWKS endpoint', (done) => {
+      const key = generateKey('kid-1');
+      const axiosStub = makeAxios(() => {
+        throw new Error('the JWKS endpoint must not be called in static key mode');
+      });
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig({ TENANT_SIGNING_KEY: key.publicPem }),
+        axiosModule: axiosStub
+      });
+
+      signingKeys.verify(sign(key), (err, payload) => {
+        expect(err).to.equal(null);
+        expect(payload.username).to.equal('jsmith');
+        expect(axiosStub.requests).to.have.length(0);
+        done();
+      });
+    });
+  });
+
+  describe('JWKS fetch failures', () => {
+    it('surfaces a verification error when the JWKS document cannot be fetched', (done) => {
+      const key = generateKey('kid-1');
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => Promise.reject(new Error('ECONNREFUSED')))
+      });
+
+      signingKeys.verify(sign(key), (err) => {
+        expect(err).to.be.ok;
+        expect(err.message).to.match(/kid "kid-1"/);
+        done();
+      });
+    });
+
+    it('rejects a JWKS document without a keys array', async () => {
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => Promise.resolve({ data: {} }))
+      });
+
+      let error;
+      await signingKeys.refresh().catch((err) => { error = err; });
+
+      expect(error).to.be.ok;
+      expect(error.message).to.match(/no "keys" array/);
+    });
+
+    it('rejects a JWKS document with no usable keys', async () => {
+      const unusable = generateKey('kid-1');
+      unusable.jwk.kty = 'OKP';
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => Promise.resolve({ data: { keys: [unusable.jwk] } }))
+      });
+
+      let error;
+      await signingKeys.refresh().catch((err) => { error = err; });
+
+      expect(error).to.be.ok;
+      expect(error.message).to.match(/No usable signing keys/);
+    });
+
+    it('keeps serving previously cached keys when a later fetch fails', async () => {
+      const key = generateKey('kid-1');
+      let shouldFail = false;
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => shouldFail
+          ? Promise.reject(new Error('ECONNREFUSED'))
+          : jwksResponse([key])),
+        cacheMaxAgeMs: 0,
+        minRefreshIntervalMs: 0
+      });
+
+      await signingKeys.refresh({ force: true });
+      shouldFail = true;
+      await signingKeys.refresh({ force: true }).catch(() => {});
+
+      // The cache was not cleared by the failed fetch, so verification still works.
+      const payload = await new Promise((resolve, reject) => {
+        signingKeys.verify(sign(key), (err, p) => err ? reject(err) : resolve(p));
+      });
+      expect(payload.username).to.equal('jsmith');
+    });
+
+    it('skips entries that are not signature keys', async () => {
+      const sigKey = generateKey('kid-sig');
+      const encKey = generateKey('kid-enc');
+      encKey.jwk.use = 'enc';
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => jwksResponse([sigKey, encKey]))
+      });
+
+      await signingKeys.refresh();
+
+      // The encryption key was dropped, so a token signed with it cannot be verified.
+      const err = await new Promise((resolve) => {
+        signingKeys.verify(sign(encKey), resolve);
+      });
+      expect(err).to.be.ok;
+      expect(err.message).to.match(/kid "kid-enc"/);
+    });
+  });
+
+  describe('refreshOnReconnect', () => {
+    it('re-reads the JWKS document when the server sent no signing key', async () => {
+      const key = generateKey('kid-1');
+      const axiosStub = makeAxios(() => jwksResponse([key]));
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: axiosStub,
+        minRefreshIntervalMs: 0
+      });
+
+      const refreshed = await signingKeys.refreshOnReconnect();
+
+      expect(refreshed).to.equal(true);
+      expect(axiosStub.requests).to.have.length(1);
+      expect(axiosStub.requests[0].url).to.equal(JWKS_URI);
+    });
+
+    it('picks up a rotated key on reconnect', async () => {
+      const oldKey = generateKey('kid-old');
+      const newKey = generateKey('kid-new');
+      let current = [oldKey];
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => jwksResponse(current)),
+        minRefreshIntervalMs: 0
+      });
+
+      await signingKeys.refreshOnReconnect();
+
+      // The tenant rotates its signing key while the socket is down.
+      current = [newKey];
+      await signingKeys.refreshOnReconnect();
+
+      const payload = await new Promise((resolve, reject) => {
+        signingKeys.verify(sign(newKey), (err, p) => err ? reject(err) : resolve(p));
+      });
+      expect(payload.username).to.equal('jsmith');
+    });
+
+    it('re-runs the provisioning ticket process when the server sent a signing key', async () => {
+      const config = makeConfig({ TENANT_SIGNING_KEY: 'an-old-key', CONNECTION: 'my-ad' });
+      const calls = [];
+      const axiosStub = makeAxios(() => {
+        throw new Error('the JWKS endpoint must not be called in static key mode');
+      });
+      const signingKeys = new SigningKeys({
+        configModule: config,
+        axiosModule: axiosStub,
+        minRefreshIntervalMs: 0,
+        // configureConnection returns the refreshed values; signingKeys persists them.
+        configureConnectionFn: async (args) => {
+          calls.push(args);
+          return { serverUrl: 'https://connector.example.com', certThumbprint: 'aa:bb', tenantSigningKey: 'a-rotated-key' };
+        }
+      });
+
+      const refreshed = await signingKeys.refreshOnReconnect();
+
+      expect(refreshed).to.equal(true);
+      expect(calls).to.have.length(1);
+      expect(calls[0].provisioningTicket).to.equal(PROVISIONING_TICKET);
+      expect(calls[0].connectionName).to.equal('my-ad');
+      expect(config.get('TENANT_SIGNING_KEY')).to.equal('a-rotated-key');
+      expect(config.saveCalls).to.equal(1);
+      expect(axiosStub.requests).to.have.length(0);
+    });
+
+    it('switches to JWKS mode when the provisioning ticket stops returning a signing key', async () => {
+      const config = makeConfig({ TENANT_SIGNING_KEY: 'an-old-key', CONNECTION: 'my-ad' });
+      const signingKeys = new SigningKeys({
+        configModule: config,
+        axiosModule: makeAxios(() => Promise.resolve({ data: { keys: [] } })),
+        minRefreshIntervalMs: 0,
+        // Simulates the tenant leaving the deprecated behaviour: no signingKey comes back.
+        configureConnectionFn: async () => ({ serverUrl: 'https://connector.example.com', certThumbprint: 'aa:bb', tenantSigningKey: '' })
+      });
+
+      expect(signingKeys.useJwks()).to.equal(false);
+      await signingKeys.refreshOnReconnect();
+
+      expect(signingKeys.useJwks()).to.equal(true);
+    });
+
+    it('does not throw when the JWKS endpoint is unreachable', async () => {
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => Promise.reject(new Error('ECONNREFUSED'))),
+        minRefreshIntervalMs: 0
+      });
+
+      const refreshed = await signingKeys.refreshOnReconnect();
+
+      expect(refreshed).to.equal(false);
+    });
+
+    it('does not throw when the provisioning ticket process fails', async () => {
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig({ TENANT_SIGNING_KEY: 'an-old-key' }),
+        minRefreshIntervalMs: 0,
+        configureConnectionFn: async () => {
+          throw new Error('Unexpected status while configuring connection: 500');
+        }
+      });
+
+      const refreshed = await signingKeys.refreshOnReconnect();
+
+      expect(refreshed).to.equal(false);
+    });
+
+    it('keeps the last known good key after a failed reconnect refresh', async () => {
+      const key = generateKey('kid-1');
+      let shouldFail = false;
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: makeAxios(() => shouldFail
+          ? Promise.reject(new Error('ECONNREFUSED'))
+          : jwksResponse([key])),
+        minRefreshIntervalMs: 0
+      });
+
+      await signingKeys.refreshOnReconnect();
+      shouldFail = true;
+      await signingKeys.refreshOnReconnect();
+
+      const payload = await new Promise((resolve, reject) => {
+        signingKeys.verify(sign(key), (err, p) => err ? reject(err) : resolve(p));
+      });
+      expect(payload.username).to.equal('jsmith');
+    });
+
+    it('throttles refreshes so a reconnect loop cannot hammer the tenant', async () => {
+      const key = generateKey('kid-1');
+      const axiosStub = makeAxios(() => jwksResponse([key]));
+      const signingKeys = new SigningKeys({
+        configModule: makeConfig(),
+        axiosModule: axiosStub,
+        minRefreshIntervalMs: 60 * 1000
+      });
+
+      await signingKeys.refreshOnReconnect();
+      await signingKeys.refreshOnReconnect();
+      await signingKeys.refreshOnReconnect();
+
+      expect(axiosStub.requests).to.have.length(1);
+    });
+  });
+});

--- a/test/ws_validator.tests.js
+++ b/test/ws_validator.tests.js
@@ -45,7 +45,25 @@ class MockWebSocket {
   }
 }
 
-class MockUsers {}
+class MockUsers {
+  validate (username, password, options, callback) {
+    callback(null, { username });
+  }
+}
+
+// Records the calls ws_validator makes into the signing key module.
+const mockSigningKeys = {
+  refreshOnReconnectCalls: 0,
+  verifyCalls: [],
+  refreshOnReconnect: async function () {
+    this.refreshOnReconnectCalls++;
+    return true;
+  },
+  verify: function (token, callback) {
+    this.verifyCalls.push(token);
+    callback(null, { username: 'jsmith', pid: 'a-pid' });
+  }
+};
 
 const mockConfig = {
   values: {},
@@ -118,6 +136,13 @@ describe('ws_validator', () => {
     'ws': MockWebSocket,
     './lib/config': mockConfig,
     './lib/users': MockUsers,
+    './lib/signingKeys': mockSigningKeys,
+    // ws_validator reads the connector's own key from disk via lib/certificates, so the in-memory
+    // config above is not enough to let it sign the authenticate token.
+    './lib/certificates': {
+      getPrivateKey: () => key,
+      getCertificate: () => cert,
+    },
   });
   
   it('authenticate_connector', () => {
@@ -143,14 +168,39 @@ describe('ws_validator', () => {
     expect(decoded.exp - testStart).to.equal(60);
   });
 
+  it('re-fetches the tenant signing key on the initial connect', () => {
+    // reconnect() runs at module load, so by now the refresh has already been requested.
+    expect(mockSigningKeys.refreshOnReconnectCalls).to.be.at.least(1);
+  });
+
+  it('verifies hub messages through the signing key module', () => {
+    const before = mockSigningKeys.verifyCalls.length;
+
+    mockWebSocketInstance.emit('authenticate_user', { jwt: 'a-hub-token' });
+
+    expect(mockSigningKeys.verifyCalls.length).to.equal(before + 1);
+    expect(mockSigningKeys.verifyCalls[before]).to.equal('a-hub-token');
+  });
+
   it('terminate socket on error', (done) => {
     mockWebSocketInstance.on('mockTerminated', () => {
       // terminate has been called on socket by the reconnection timer, all good.
       done();
     });
-    
+
     // trigger error
     mockWebSocketInstance.emit('error', new Error('test'));
+  });
+
+  it('re-fetches the tenant signing key on reconnect', (done) => {
+    const before = mockSigningKeys.refreshOnReconnectCalls;
+
+    // The reconnection timer rebuilds the socket after WS_RECONNECT_INTERVAL_MS, which must
+    // refresh the signing key before connecting again.
+    setTimeout(() => {
+      expect(mockSigningKeys.refreshOnReconnectCalls).to.be.above(before);
+      done();
+    }, 2500);
   });
 
 });

--- a/ws_validator.js
+++ b/ws_validator.js
@@ -26,6 +26,7 @@ const WrongUsername = require('./lib/errors/WrongUsername');
 const InsufficientAccessRightsError = require('./lib/errors/InsufficientAccessRightsError');
 const PasswordComplexityError = require('./lib/errors/PasswordComplexityError');
 const certificates = require('./lib/certificates');
+const signingKeys = require('./lib/signingKeys');
 var ws;
 
 const emitter = new EventEmitter();
@@ -140,7 +141,7 @@ async function setupWebsocket() {
         openedSocket = false;
       }
     }).on('authenticate_user', function (msg) {
-      jwt.verify(msg.jwt, config.get('TENANT_SIGNING_KEY'), function (err, payload) {
+      signingKeys.verify(msg.jwt, function (err, payload) {
         if (err) {
           console.error('Unauthorized attemp of authentication.');
           return;
@@ -245,7 +246,7 @@ async function setupWebsocket() {
         });
       });
     }).on('search_users', function (msg) {
-      jwt.verify(msg.jwt, config.get('TENANT_SIGNING_KEY'), function (err, payload) {
+      signingKeys.verify(msg.jwt, function (err, payload) {
         if (err) {
           console.error('Unauthorized attemp of search_users.');
           return;
@@ -269,7 +270,7 @@ async function setupWebsocket() {
         });
       });
     }).on('list_groups', function(msg) {
-      jwt.verify(msg.jwt, config.get('TENANT_SIGNING_KEY'), function(err, payload) {
+      signingKeys.verify(msg.jwt, function(err, payload) {
         if (err) {
           console.error('Unauthorized attempt of list_groups');
           return;
@@ -296,7 +297,7 @@ async function setupWebsocket() {
     // Listen only for change_password event when write back is enabled.
     if (config.get('ENABLE_WRITE_BACK')) {
       ws.on('change_password', function (command) {
-        jwt.verify(command.jwt, config.get('TENANT_SIGNING_KEY'), function (err, payload) {
+        signingKeys.verify(command.jwt, function (err, payload) {
           if (err) {
             console.error('Unauthorized change_password attempt');
             return;
@@ -361,6 +362,13 @@ async function setupWebsocket() {
 
 async function reconnect() {
   try {
+    // The hub may have rotated the key it signs messages with while the socket was down, so the
+    // key captured during setup cannot be assumed current. Depending on what auth0-server replied
+    // with during the provisioning ticket process, this either re-reads the JWKS document or runs
+    // the provisioning ticket process again. Failures are logged and swallowed inside
+    // refreshOnReconnect so that a temporarily unreachable tenant never blocks the reconnect.
+    await signingKeys.refreshOnReconnect();
+
     console.log('Connecting to websocket...');
     await setupWebsocket();
     console.log('Connected to websocket');


### PR DESCRIPTION
## Re-fetch signing keys on reconnect + support JWKS

The connector previously fetched a signing key once during provisioning and reused it for the process lifetime; on reconnect it never re-fetched, so a hub-side key rotation left it unable to verify messages.

### Acceptance criteria
- **Reports `capabilities.useJWKS`** — the provisioning-ticket POST now includes `capabilities: { useJWKS: true }`, sent unconditionally (the connector cannot inspect a tenant's deprecation status; it just advertises that it can read the JWKS document itself). `lib/configureConnection.js`.
- **Re-fetches the signing key on reconnect** — `ws_validator.js#reconnect()` now `await`s `signingKeys.refreshOnReconnect()` before re-establishing the socket.
- **Two resolution modes**, chosen by what auth0-server returns during provisioning:
  - **No `signingKey`** → tenant is in the final non-deprecated state → the connector reads the tenant signing key from `/.well-known/jwks.json`, selecting by `kid` (JWKS mode).
  - **A `signingKey`** → still a deprecated variation (or an older server that ignores `capabilities`) → the connector re-runs the provisioning-ticket process (static mode). This keeps older servers working unchanged.

### Implementation notes
- New `lib/signingKeys.js` owns key resolution and verification. JWKS fetches are cached with a freshness window (10m) and a cooldown floor (30s); an unknown `kid` forces a re-fetch to pick up rotation; a failed fetch retains the last-known-good keys rather than wedging the connector.
- **Crypto hardening:** verification (both JWKS and static/deprecated modes) is constrained to an asymmetric algorithm allow-list (RS/PS/ES); `none` and the HMAC family are rejected, closing the algorithm-confusion vector where a published public key is replayed as an HMAC secret. Note this also hardens the pre-existing static path, which previously passed no `algorithms` option to `jsonwebtoken`.
- `refreshViaProvisioningTicket` persists config only when the key actually changed, avoiding a disk write on every reconnect.

### Testing
- `test/signingKeys.tests.js`, `test/configureConnection.tests.js`, `test/ws_validator.tests.js` — 52 passing locally, including kid selection, unknown-kid re-fetch, forged-key/HS256-confusion rejection (JWKS *and* static mode), caching, concurrent-fetch sharing, last-known-good retention, and reconnect refresh in both modes.

### Notes for reviewers
- Rebased on current `master`, including the recent `configureConnection` refactor (moved to `lib/` and now returns `{ serverUrl, certThumbprint, tenantSigningKey }`); this branch adapts to that return-based contract.
- The PSIRT this ticket was gated behind has merged, so this is clear to review/merge.
- Pre-existing on `master` and unrelated to this change: the full `npm test` suite exits non-zero on a few SSL/LDAP-fixture tests, and `npm run lint:check` floods `describe/it is not defined` because the eslint config lacks a mocha env for `test/**`. The files changed here lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)